### PR TITLE
Renamed RequestWithTransientlyHandledResponse to Request

### DIFF
--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_a_callback_for_local_message.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_a_callback_for_local_message.cs
@@ -18,7 +18,7 @@ namespace NServiceBus.AcceptanceTests.Callbacks
 
                             options.RouteToLocalEndpointInstance();
 
-                            var response = bus.RequestWithTransientlyHandledResponse<MyResponse>(new MyRequest(), options);
+                            var response = bus.Request<MyResponse>(new MyRequest(), options);
 
                             await response;
                             

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_a_callback_for_local_message_canceled.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_a_callback_for_local_message_canceled.cs
@@ -26,7 +26,7 @@ namespace NServiceBus.AcceptanceTests.Callbacks
                             options.RouteToLocalEndpointInstance();
                             options.RegisterCancellationToken(cs.Token);
 
-                            var response = bus.RequestWithTransientlyHandledResponse<MyResponse>(new MyRequest(), options);
+                            var response = bus.Request<MyResponse>(new MyRequest(), options);
 
                             try
                             {

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_enum_response_canceled.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_enum_response_canceled.cs
@@ -24,7 +24,7 @@
 
                     options.RegisterCancellationToken(cs.Token);
 
-                    var response = bus.RequestWithTransientlyHandledResponse<OldEnum>(new MyRequest(), options);
+                    var response = bus.Request<OldEnum>(new MyRequest(), options);
                     try
                     {
                         c.Response = await response;

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_int_response_canceled.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_int_response_canceled.cs
@@ -24,7 +24,7 @@ namespace NServiceBus.AcceptanceTests.Callbacks
 
                     options.RegisterCancellationToken(cs.Token);
 
-                    var response = bus.RequestWithTransientlyHandledResponse<int>(new MyRequest(), options);
+                    var response = bus.Request<int>(new MyRequest(), options);
                     try
                     {
                         c.Response = await response;

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_using_callback_to_get_message.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_using_callback_to_get_message.cs
@@ -15,7 +15,7 @@
             Scenario.Define(context)
                 .WithEndpoint<EndpointWithLocalCallback>(b => b.Given(async (bus, c) =>
                 {
-                    var response = bus.RequestWithTransientlyHandledResponse<MyResponse>(new MyRequest(), new SendOptions());
+                    var response = bus.Request<MyResponse>(new MyRequest(), new SendOptions());
 
                     c.Response = await response;
                     c.CallbackFired = true;

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_using_callback_to_get_message_canceled.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_using_callback_to_get_message_canceled.cs
@@ -24,7 +24,7 @@
 
                     options.RegisterCancellationToken(cs.Token);
 
-                    var response = bus.RequestWithTransientlyHandledResponse<MyResponse>(new MyRequest(), options);
+                    var response = bus.Request<MyResponse>(new MyRequest(), options);
 
                     try
                     {

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_using_callbacks_in_a_scaleout.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_using_callbacks_in_a_scaleout.cs
@@ -18,7 +18,7 @@
                     .WithEndpoint<Client>(b => b.CustomConfig(c => RuntimeEnvironment.MachineNameAction = () => "ClientA")
                         .Given((bus, context) =>
                         {
-                            bus.RequestWithTransientlyHandledResponse<MyResponse>(new MyRequest
+                            bus.Request<MyResponse>(new MyRequest
                             {
                                 Id = context.Id,
                                 Client = RuntimeEnvironment.MachineName
@@ -28,7 +28,7 @@
                     .WithEndpoint<Client>(b => b.CustomConfig(c => RuntimeEnvironment.MachineNameAction = () => "ClientB")
                         .Given((bus, context) =>
                         {
-                            bus.RequestWithTransientlyHandledResponse<MyResponse>(new MyRequest
+                            bus.Request<MyResponse>(new MyRequest
                             {
                                 Id = context.Id,
                                 Client = RuntimeEnvironment.MachineName

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_using_callbacks_with_messageid_eq_cid.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_using_callbacks_with_messageid_eq_cid.cs
@@ -19,7 +19,7 @@
                         options.SetMessageId(id);
                         options.RouteToLocalEndpointInstance();
 
-                        await bus.RequestWithTransientlyHandledResponse<MyResponse>(new MyRequest(), options);
+                        await bus.Request<MyResponse>(new MyRequest(), options);
 
                         c.CallbackFired = true;
                     }))

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_using_enum_response.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_using_enum_response.cs
@@ -15,7 +15,7 @@
             Scenario.Define(context)
                 .WithEndpoint<EndpointWithLocalCallback>(b => b.Given(async (bus, c) =>
                 {
-                    var response = bus.RequestWithTransientlyHandledResponse<OldEnum>(new MyRequest(), new SendOptions());
+                    var response = bus.Request<OldEnum>(new MyRequest(), new SendOptions());
 
                     c.Response = await response;
                     c.CallbackFired = true;

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_using_int_response.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_using_int_response.cs
@@ -15,7 +15,7 @@
             Scenario.Define(context)
                 .WithEndpoint<EndpointWithLocalCallback>(b => b.Given(async (bus, c) =>
                 {
-                    var response = bus.RequestWithTransientlyHandledResponse<int>(new MyRequest(), new SendOptions());
+                    var response = bus.Request<int>(new MyRequest(), new SendOptions());
 
                     c.Response = await response;
                     c.CallbackFired = true;

--- a/src/NServiceBus.Callbacks.Tests/API/APIApprovals.ApproveCallbacks.approved.txt
+++ b/src/NServiceBus.Callbacks.Tests/API/APIApprovals.ApproveCallbacks.approved.txt
@@ -3,12 +3,12 @@
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.5.1", FrameworkDisplayName=".NET Framework 4.5.1")]
 namespace NServiceBus
 {
+    public class static RequestResponseExtensions
+    {
+        public static System.Threading.Tasks.Task<TResponse> Request<TResponse>(this NServiceBus.IBus bus, object requestMessage, NServiceBus.SendOptions options) { }
+    }
     public class static SendOptionsExtensions
     {
         public static NServiceBus.SendOptions RegisterCancellationToken(this NServiceBus.SendOptions options, System.Threading.CancellationToken cancellationToken) { }
-    }
-    public class static TransientRequestResponseExtensions
-    {
-        public static System.Threading.Tasks.Task<TResponse> RequestWithTransientlyHandledResponse<TResponse>(this NServiceBus.IBus bus, object requestMessage, NServiceBus.SendOptions options) { }
     }
 }

--- a/src/NServiceBus.Callbacks.Tests/API/APIApprovals.cs
+++ b/src/NServiceBus.Callbacks.Tests/API/APIApprovals.cs
@@ -16,7 +16,7 @@
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void ApproveCallbacks()
         {
-            var assemblyPath = Path.GetFullPath(typeof(TransientRequestResponseExtensions).Assembly.Location);
+            var assemblyPath = Path.GetFullPath(typeof(RequestResponseExtensions).Assembly.Location);
             var asm = AssemblyDefinition.ReadAssembly(assemblyPath);
             var publicApi = Filter(PublicApiGenerator.CreatePublicApiForAssembly(asm));
             Approvals.Verify(publicApi);

--- a/src/NServiceBus.Callbacks/NServiceBus.Callbacks.csproj
+++ b/src/NServiceBus.Callbacks/NServiceBus.Callbacks.csproj
@@ -54,7 +54,7 @@
     <Compile Include="CallbackResponseHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TaskCompletionSourceAdapter.cs" />
-    <Compile Include="TransientRequestResponseExtensions.cs" />
+    <Compile Include="RequestResponseExtensions.cs" />
     <Compile Include="RequestResponseInvocationBehavior.cs" />
     <Compile Include="RequestResponseStateLookup.cs" />
     <Compile Include="UpdateRequestResponseCorrelationTableBehavior.cs" />

--- a/src/NServiceBus.Callbacks/RequestResponseExtensions.cs
+++ b/src/NServiceBus.Callbacks/RequestResponseExtensions.cs
@@ -7,7 +7,7 @@
     /// <summary>
     ///  Request/response extension methods.
     /// </summary>
-    public static class TransientRequestResponseExtensions
+    public static class RequestResponseExtensions
     {
         /// <summary>
         /// Sends a <paramref name="requestMessage"/> to the configured destination and returns back a <see cref="Task{TResponse}"/> which can be awaited.
@@ -20,7 +20,7 @@
         /// <param name="requestMessage">The request message.</param>
         /// <param name="options">The options for the send.</param>
         /// <returns>A task which contains the response when it is completed.</returns>
-        public static Task<TResponse> RequestWithTransientlyHandledResponse<TResponse>(this IBus bus, object requestMessage, SendOptions options)
+        public static Task<TResponse> Request<TResponse>(this IBus bus, object requestMessage, SendOptions options)
         {
             if (requestMessage == null)
             {


### PR DESCRIPTION
In today's retrospective @johnsimons brought up a valid point which made us revert our decision to reflect the transient nature of the API in the request API name.

Consider the following code:

```
// some code
var response = await bus.RequestWithTransientlyHandledResponse<TResponse>(new TRequest());
// some code
```

The long name is unnecessary because of the nature how this API is now used in combination with `async/await`. The code is now, in contrast to the old API, no longer using a lambda clojure to handle the response but uses async/await. By the nature how this API is used users know that the code can't resume when the application shuts down.
