### PR TITLE
update to latest v6 unstable

### DIFF
--- a/src/NServiceBus.Callbacks.AcceptanceTests/ConfigureInMemoryPersistence.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/ConfigureInMemoryPersistence.cs
@@ -6,7 +6,7 @@ using NServiceBus.AcceptanceTesting.Support;
 
 public class ConfigureInMemoryPersistence : IConfigureTestExecution
 {
-    public Task Configure(BusConfiguration configuration, IDictionary<string, string> settings)
+    public Task Configure(EndpointConfiguration configuration, IDictionary<string, string> settings)
     {
         configuration.UsePersistence<InMemoryPersistence>();
         return Task.FromResult(0);

--- a/src/NServiceBus.Callbacks.AcceptanceTests/ConfigureMsmqTransport.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/ConfigureMsmqTransport.cs
@@ -10,18 +10,18 @@ using NServiceBus.Transports;
 
 public class ConfigureMsmqTransport : IConfigureTestExecution
 {
-    BusConfiguration busConfiguration;
+    EndpointConfiguration configuration;
 
-    public Task Configure(BusConfiguration configuration, IDictionary<string, string> settings)
+    public Task Configure(EndpointConfiguration configuration, IDictionary<string, string> settings)
     {
-        busConfiguration = configuration;
+        this.configuration = configuration;
         configuration.UseTransport<MsmqTransport>().ConnectionString(settings["Transport.ConnectionString"]);
         return Task.FromResult(0);
     }
 
     public Task Cleanup()
     {
-        var bindings = busConfiguration.GetSettings().Get<QueueBindings>();
+        var bindings = configuration.GetSettings().Get<QueueBindings>();
         var allQueues = MessageQueue.GetPrivateQueuesByMachine("localhost");
         var queuesToBeDeleted = new List<string>();
 

--- a/src/NServiceBus.Callbacks.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
@@ -6,6 +6,7 @@
     using NServiceBus.AcceptanceTesting.Support;
     using NServiceBus.Configuration.AdvanceExtensibility;
     using ScenarioDescriptors;
+    using EndpointConfiguration = NServiceBus.EndpointConfiguration;
 
     public static class ConfigureExtensions
     {
@@ -19,7 +20,7 @@
             return dictionary[key];
         }
 
-        public static Task DefineTransport(this BusConfiguration config, IDictionary<string, string> settings, Type endpointBuilderType)
+        public static Task DefineTransport(this EndpointConfiguration config, IDictionary<string, string> settings, Type endpointBuilderType)
         {
             if (!settings.ContainsKey("Transport"))
             {
@@ -31,7 +32,7 @@
 
         }
 
-        public static Task DefinePersistence(this BusConfiguration config, IDictionary<string, string> settings)
+        public static Task DefinePersistence(this EndpointConfiguration config, IDictionary<string, string> settings)
         {
             if (!settings.ContainsKey("Persistence"))
             {
@@ -47,7 +48,7 @@
             Persistence
         }
 
-        private static async Task ConfigureTestExecution(TestDependencyType type, BusConfiguration config, IDictionary<string, string> settings)
+        static async Task ConfigureTestExecution(TestDependencyType type, EndpointConfiguration config, IDictionary<string, string> settings)
         {
             var dependencyTypeString = type.ToString();
 
@@ -78,15 +79,7 @@
             cleaners.Add(configurer);
         }
 
-        class Cleaner
-        {
-            public Task Cleanup()
-            {
-                return Task.FromResult(0);
-            }
-        }
-
-        public static void DefineBuilder(this BusConfiguration config, IDictionary<string, string> settings)
+        public static void DefineBuilder(this EndpointConfiguration config, IDictionary<string, string> settings)
         {
             if (!settings.ContainsKey("Builder"))
             {

--- a/src/NServiceBus.Callbacks.AcceptanceTests/EndpointTemplates/DefaultPublisher.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/EndpointTemplates/DefaultPublisher.cs
@@ -7,7 +7,7 @@ namespace NServiceBus.AcceptanceTests.EndpointTemplates
 
     public class DefaultPublisher : IEndpointSetupTemplate
     {
-        public Task<BusConfiguration> GetConfiguration(RunDescriptor runDescriptor, EndpointConfiguration endpointConfiguration, IConfigurationSource configSource, Action<BusConfiguration> configurationBuilderCustomization)
+        public Task<EndpointConfiguration> GetConfiguration(RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointConfiguration, IConfigurationSource configSource, Action<EndpointConfiguration> configurationBuilderCustomization)
         {
             return new DefaultServer().GetConfiguration(runDescriptor, endpointConfiguration, configSource, configurationBuilderCustomization);
         }

--- a/src/NServiceBus.Callbacks.AcceptanceTests/NServiceBus.Callbacks.AcceptanceTests.csproj
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/NServiceBus.Callbacks.AcceptanceTests.csproj
@@ -31,11 +31,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NServiceBus.AcceptanceTesting, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.AcceptanceTesting.6.0.0-unstable1423\lib\net452\NServiceBus.AcceptanceTesting.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.AcceptanceTesting.6.0.0-unstable1509\lib\net452\NServiceBus.AcceptanceTesting.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.6.0.0-unstable1423\lib\net452\NServiceBus.Core.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.6.0.0-unstable1509\lib\net452\NServiceBus.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework">

--- a/src/NServiceBus.Callbacks.AcceptanceTests/packages.config
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NServiceBus" version="6.0.0-unstable1423" targetFramework="net452" />
-  <package id="NServiceBus.AcceptanceTesting" version="6.0.0-unstable1423" targetFramework="net452" />
+  <package id="NServiceBus" version="6.0.0-unstable1509" targetFramework="net452" />
+  <package id="NServiceBus.AcceptanceTesting" version="6.0.0-unstable1509" targetFramework="net452" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>

--- a/src/NServiceBus.Callbacks.Tests/API/APIApprovals.ApproveCallbacks.approved.txt
+++ b/src/NServiceBus.Callbacks.Tests/API/APIApprovals.ApproveCallbacks.approved.txt
@@ -5,7 +5,7 @@ namespace NServiceBus
 {
     public class static RequestResponseExtensions
     {
-        public static async System.Threading.Tasks.Task<TResponse> Request<TResponse>(this NServiceBus.IBusSession session, object requestMessage, NServiceBus.SendOptions options) { }
+        public static async System.Threading.Tasks.Task<TResponse> Request<TResponse>(this NServiceBus.IMessageSession session, object requestMessage, NServiceBus.SendOptions options) { }
     }
     public class static SendOptionsExtensions
     {

--- a/src/NServiceBus.Callbacks/NServiceBus.Callbacks.csproj
+++ b/src/NServiceBus.Callbacks/NServiceBus.Callbacks.csproj
@@ -41,7 +41,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.6.0.0-unstable1423\lib\net452\NServiceBus.Core.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.6.0.0-unstable1509\lib\net452\NServiceBus.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/NServiceBus.Callbacks/RequestResponseExtensions.cs
+++ b/src/NServiceBus.Callbacks/RequestResponseExtensions.cs
@@ -20,7 +20,7 @@
         /// <param name="requestMessage">The request message.</param>
         /// <param name="options">The options for the send.</param>
         /// <returns>A task which contains the response when it is completed.</returns>
-        public static async Task<TResponse> Request<TResponse>(this IBusSession session, object requestMessage, SendOptions options)
+        public static async Task<TResponse> Request<TResponse>(this IMessageSession session, object requestMessage, SendOptions options)
         {
             if (requestMessage == null)
             {

--- a/src/NServiceBus.Callbacks/packages.config
+++ b/src/NServiceBus.Callbacks/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="GitVersionTask" version="2.0.1" targetFramework="net45" developmentDependency="true" />
-  <package id="NServiceBus" version="6.0.0-unstable1423" targetFramework="net452" />
+  <package id="NServiceBus" version="6.0.0-unstable1509" targetFramework="net452" />
   <package id="NuGetPackager" version="0.5.5" targetFramework="net451" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Should we consider moving the callback extension methods to work with `IEndpointInstance` instead of `IMessageSession`?