### PR TITLE
TrySetCanceled and RequestResponseParameters as struct

### DIFF
--- a/src/NServiceBus.Callbacks/ExtendableOptionsExtensions.cs
+++ b/src/NServiceBus.Callbacks/ExtendableOptionsExtensions.cs
@@ -17,10 +17,10 @@
             {
                 data = new UpdateRequestResponseCorrelationTableBehavior.RequestResponseParameters
                 {
-                    CancellationToken = cancellationToken
+                    CancellationToken = cancellationToken,
                 };
-                extensions.Set(data);
             }
+            extensions.Set(data);
         }
     }
 }

--- a/src/NServiceBus.Callbacks/RequestResponseExtensions.cs
+++ b/src/NServiceBus.Callbacks/RequestResponseExtensions.cs
@@ -88,10 +88,11 @@
             {
                 data = new UpdateRequestResponseCorrelationTableBehavior.RequestResponseParameters
                 {
-                    TaskCompletionSource = adapter
+                    TaskCompletionSource = adapter,
+                    CancellationToken = CancellationToken.None
                 };
-                extensions.Set(data);
             }
+            extensions.Set(data);
             return data;
         }
     }

--- a/src/NServiceBus.Callbacks/TaskCompletionSourceAdapter.cs
+++ b/src/NServiceBus.Callbacks/TaskCompletionSourceAdapter.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus
 {
     using System;
+    using System.Threading;
 
     class TaskCompletionSourceAdapter
     {
@@ -20,14 +21,21 @@ namespace NServiceBus
             });
         }
 
-        public void SetCancelled()
+        public void TrySetCanceled()
         {
-            var method = taskCompletionSource.GetType().GetMethod("SetCanceled");
-            method.Invoke(taskCompletionSource, new object[]
-            {
-            });
+            var method = taskCompletionSource.GetType().GetMethod("TrySetCanceled", TrySetCancelledArgumentTypes);
+            method.Invoke(taskCompletionSource, TrySetCancelledArguments);
         }
 
         object taskCompletionSource;
+
+        static Type[] TrySetCancelledArgumentTypes = {
+            typeof(CancellationToken)
+        };
+
+        static object[] TrySetCancelledArguments =
+        {
+            CancellationToken.None
+        };
     }
 }


### PR DESCRIPTION
Was reviewing callbacks and found two optimizations

* Using `TrySetCanceled` instead of `Canceled `to align with `TrySetResult`
* `RequestResponseParameters` is now a struct and manages only one registration

While doing this I found a leakage. Will send in another PR shortly and open up an issue.

@Particular/nservicebus-maintainers please review