### PR TITLE
Additional overload for request without needing to specify the send options

### DIFF
--- a/src/NServiceBus.Callbacks.Tests/API/APIApprovals.ApproveCallbacks.approved.txt
+++ b/src/NServiceBus.Callbacks.Tests/API/APIApprovals.ApproveCallbacks.approved.txt
@@ -6,6 +6,8 @@ namespace NServiceBus
 {
     public class static RequestResponseExtensions
     {
+        public static System.Threading.Tasks.Task<TResponse> Request<TResponse>(this NServiceBus.IMessageSession session, object requestMessage) { }
+        public static System.Threading.Tasks.Task<TResponse> Request<TResponse>(this NServiceBus.IMessageSession session, object requestMessage, System.Threading.CancellationToken cancellationToken) { }
         public static System.Threading.Tasks.Task<TResponse> Request<TResponse>(this NServiceBus.IMessageSession session, object requestMessage, NServiceBus.SendOptions options) { }
         public static async System.Threading.Tasks.Task<TResponse> Request<TResponse>(this NServiceBus.IMessageSession session, object requestMessage, NServiceBus.SendOptions options, System.Threading.CancellationToken cancellationToken) { }
     }

--- a/src/NServiceBus.Callbacks/RequestResponseExtensions.cs
+++ b/src/NServiceBus.Callbacks/RequestResponseExtensions.cs
@@ -22,6 +22,43 @@
         /// <typeparam name="TResponse">The response type.</typeparam>
         /// <param name="session">The session.</param>
         /// <param name="requestMessage">The request message.</param>
+        /// <returns>A task which contains the response when it is completed.</returns>
+        public static Task<TResponse> Request<TResponse>(this IMessageSession session, object requestMessage)
+        {
+            return session.Request<TResponse>(requestMessage, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Sends a <paramref name="requestMessage" /> to the configured destination and returns back a
+        /// <see cref="Task{TResponse}" /> which can be awaited.
+        /// </summary>
+        /// <remarks>
+        /// The task returned is non durable. When the AppDomain is unloaded or the response task is canceled.
+        /// Messages can still arrive to the requesting endpoint but in that case no handling code will be attached to consume
+        /// that response message and therefore the message will be moved to the error queue.
+        /// </remarks>
+        /// <typeparam name="TResponse">The response type.</typeparam>
+        /// <param name="session">The session.</param>
+        /// <param name="requestMessage">The request message.</param>
+        /// <param name="cancellationToken">The cancellation token used to cancel the request.</param>
+        /// <returns>A task which contains the response when it is completed.</returns>
+        public static Task<TResponse> Request<TResponse>(this IMessageSession session, object requestMessage, CancellationToken cancellationToken)
+        {
+            return session.Request<TResponse>(requestMessage, new SendOptions(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Sends a <paramref name="requestMessage" /> to the configured destination and returns back a
+        /// <see cref="Task{TResponse}" /> which can be awaited.
+        /// </summary>
+        /// <remarks>
+        /// The task returned is non durable. When the AppDomain is unloaded or the response task is canceled.
+        /// Messages can still arrive to the requesting endpoint but in that case no handling code will be attached to consume
+        /// that response message and therefore the message will be moved to the error queue.
+        /// </remarks>
+        /// <typeparam name="TResponse">The response type.</typeparam>
+        /// <param name="session">The session.</param>
+        /// <param name="requestMessage">The request message.</param>
         /// <param name="options">The options for the send.</param>
         /// <returns>A task which contains the response when it is completed.</returns>
         public static Task<TResponse> Request<TResponse>(this IMessageSession session, object requestMessage, SendOptions options)


### PR DESCRIPTION
While reviewing http://docs.particular.net/nservicebus/messaging/handling-responses-on-the-client-side#cancellation I realized that we force the users to always pass in the `SendOptions`. That is cumbersome. I provided overloads which don't need `SendOptions` but still support cancellation

@Particular/nservicebus-maintainers please review