### PR TITLE
Add message contructor extension methods to Request

### DIFF
--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_a_callback_for_local_message.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_a_callback_for_local_message.cs
@@ -8,8 +8,9 @@ namespace NServiceBus.AcceptanceTests.Callbacks
 
     public class When_a_callback_for_local_message : NServiceBusAcceptanceTest
     {
-        [Test]
-        public async Task Should_trigger_the_callback_when_the_response_comes_back()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Should_trigger_the_callback_when_the_response_comes_back(bool useAction)
         {
             await Scenario.Define<Context>()
                 .WithEndpoint<EndpointWithLocalCallback>(b => b.When(async (bus, context) =>
@@ -18,7 +19,10 @@ namespace NServiceBus.AcceptanceTests.Callbacks
 
                     options.RouteToThisEndpoint();
 
-                    await bus.Request<MyResponse>(new MyRequest(), options);
+                    if (useAction)
+                        await bus.Request<MyRequest, MyResponse>(x => { }, options);
+                    else
+                        await bus.Request<MyResponse>(new MyRequest(), options);
 
                     Assert.True(context.HandlerGotTheRequest);
                     context.CallbackFired = true;

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_a_callback_for_local_message_canceled.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_a_callback_for_local_message_canceled.cs
@@ -10,8 +10,9 @@ namespace NServiceBus.AcceptanceTests.Callbacks
 
     public class When_a_callback_for_local_message_canceled : NServiceBusAcceptanceTest
     {
-        [Test]
-        public async Task ShouldNot_trigger_the_callback_when_canceled()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task ShouldNot_trigger_the_callback_when_canceled(bool useAction)
         {
             OperationCanceledException exception = null;
 
@@ -27,7 +28,10 @@ namespace NServiceBus.AcceptanceTests.Callbacks
 
                     try
                     {
-                        ctx.Response = await bus.Request<MyResponse>(new MyRequest(), options, cs.Token);
+                        if (useAction)
+                            ctx.Response = await bus.Request<MyRequest, MyResponse>(x => { }, options, cs.Token);
+                        else
+                            ctx.Response = await bus.Request<MyResponse>(new MyRequest(), options, cs.Token);
                         ctx.CallbackFired = true;
                     }
                     catch (OperationCanceledException e)

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_enum_response_canceled.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_enum_response_canceled.cs
@@ -15,8 +15,9 @@
             Success
         }
 
-        [Test]
-        public async Task ShouldNot_trigger_the_callback_when_canceled()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task ShouldNot_trigger_the_callback_when_canceled(bool useAction)
         {
             OperationCanceledException exception = null;
 
@@ -30,7 +31,10 @@
 
                     try
                     {
-                        c.Response = await bus.Request<OldEnum>(new MyRequest(), options, cs.Token);
+                        if (useAction)
+                            c.Response = await bus.Request<MyRequest, OldEnum>(x => { }, options, cs.Token);
+                        else
+                            c.Response = await bus.Request<OldEnum>(new MyRequest(), options, cs.Token);
                         c.CallbackFired = true;
                     }
                     catch (OperationCanceledException e)

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_int_response_canceled.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_int_response_canceled.cs
@@ -9,8 +9,9 @@ namespace NServiceBus.AcceptanceTests.Callbacks
 
     public class When_int_response_canceled : NServiceBusAcceptanceTest
     {
-        [Test]
-        public async Task ShouldNot_trigger_the_callback_when_canceled()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task ShouldNot_trigger_the_callback_when_canceled(bool useAction)
         {
             OperationCanceledException exception = null;
 
@@ -24,7 +25,10 @@ namespace NServiceBus.AcceptanceTests.Callbacks
 
                     try
                     {
-                        c.Response = await bus.Request<int>(new MyRequest(), options, cs.Token);
+                        if (useAction)
+                            c.Response = await bus.Request<MyRequest, int>(x => { }, options, cs.Token);
+                        else
+                            c.Response = await bus.Request<int>(new MyRequest(), options, cs.Token);
                         c.CallbackFired = true;
                     }
                     catch (OperationCanceledException e)

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_using_callback_to_get_message.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_using_callback_to_get_message.cs
@@ -7,13 +7,17 @@
 
     public class When_using_callback_to_get_message : NServiceBusAcceptanceTest
     {
-        [Test]
-        public async Task Should_receive_message()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Should_receive_message(bool useAction)
         {
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<EndpointWithLocalCallback>(b => b.When(async (bus, c) =>
                 {
-                    c.Response = await bus.Request<MyResponse>(new MyRequest(), new SendOptions());
+                    if (useAction)
+                        c.Response = await bus.Request<MyRequest, MyResponse>(x => { }, new SendOptions());
+                    else
+                        c.Response = await bus.Request<MyResponse>(new MyRequest(), new SendOptions());
                     c.CallbackFired = true;
                 }))
                 .WithEndpoint<Replier>()

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_using_callback_to_get_message_canceled.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_using_callback_to_get_message_canceled.cs
@@ -9,8 +9,9 @@
 
     public class When_using_callback_to_get_message_canceled : NServiceBusAcceptanceTest
     {
-        [Test]
-        public async Task ShouldNot_trigger_the_callback_when_canceled()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task ShouldNot_trigger_the_callback_when_canceled(bool useAction)
         {
             OperationCanceledException exception = null;
 
@@ -25,7 +26,10 @@
 
                     try
                     {
-                        ctx.Response = await bus.Request<MyResponse>(new MyRequest(), options, cs.Token);
+                        if (useAction)
+                            ctx.Response = await bus.Request<MyRequest, MyResponse>(x => { }, options, cs.Token);
+                        else
+                            ctx.Response = await bus.Request<MyResponse>(new MyRequest(), options, cs.Token);
                         ctx.CallbackFired = true;
                     }
                     catch (OperationCanceledException e)

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_using_callbacks_with_messageid_eq_cid.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_using_callbacks_with_messageid_eq_cid.cs
@@ -8,8 +8,9 @@
 
     public class When_using_callbacks_with_messageid_eq_cid : NServiceBusAcceptanceTest
     {
-        [Test]
-        public async Task Should_trigger_the_callback()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Should_trigger_the_callback(bool useAction)
         {
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<EndpointWithLocalCallback>(b => b.When(async (bus, c) =>
@@ -20,7 +21,10 @@
                     options.SetMessageId(id);
                     options.RouteToThisEndpoint();
 
-                    await bus.Request<MyResponse>(new MyRequest(), options);
+                    if (useAction)
+                        await bus.Request<MyRequest, MyResponse>(x => { }, options);
+                    else
+                        await bus.Request<MyResponse>(new MyRequest(), options);
 
                     c.CallbackFired = true;
                 }))

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_using_enum_response.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_using_enum_response.cs
@@ -13,13 +13,17 @@
             Success
         }
 
-        [Test]
-        public async Task Should_send_back_old_style_control_message()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Should_send_back_old_style_control_message(bool useAction)
         {
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<EndpointWithLocalCallback>(b => b.When(async (bus, c) =>
                 {
-                    c.Response = await bus.Request<OldEnum>(new MyRequest(), new SendOptions());
+                    if (useAction)
+                        c.Response = await bus.Request<MyRequest, OldEnum>(x => { }, new SendOptions());
+                    else
+                        c.Response = await bus.Request<OldEnum>(new MyRequest(), new SendOptions());
                     c.CallbackFired = true;
                 }))
                 .WithEndpoint<Replier>()

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_using_enum_response_and_conventions.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_using_enum_response_and_conventions.cs
@@ -14,13 +14,17 @@
             Success
         }
 
-        [Test]
-        public async Task Should_send_back_old_style_control_message()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Should_send_back_old_style_control_message(bool useAction)
         {
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<EndpointWithLocalCallback>(b => b.When(async (bus, c) =>
                 {
-                    c.Response = await bus.Request<OldEnum>(new MyRequest(), new SendOptions());
+                    if (useAction)
+                        c.Response = await bus.Request<MyRequest, OldEnum>(x => { }, new SendOptions());
+                    else
+                        c.Response = await bus.Request<OldEnum>(new MyRequest(), new SendOptions());
                     c.CallbackFired = true;
                 }))
                 .WithEndpoint<Replier>()

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_using_int_response.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_using_int_response.cs
@@ -7,13 +7,17 @@
 
     public class When_using_int_response : NServiceBusAcceptanceTest
     {
-        [Test]
-        public async Task Should_send_back_old_style_control_message()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Should_send_back_old_style_control_message(bool useAction)
         {
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<EndpointWithLocalCallback>(b => b.When(async (bus, c) =>
                 {
-                    c.Response = await bus.Request<int>(new MyRequest(), new SendOptions());
+                    if (useAction)
+                        c.Response = await bus.Request<MyRequest, int>(x => { }, new SendOptions());
+                    else
+                        c.Response = await bus.Request<int>(new MyRequest(), new SendOptions());
                     c.CallbackFired = true;
                 }))
                 .WithEndpoint<Replier>()

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_using_int_response_and_conventions.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_using_int_response_and_conventions.cs
@@ -8,13 +8,17 @@
 
     public class When_using_int_response_and_conventions : NServiceBusAcceptanceTest
     {
-        [Test]
-        public async Task Should_send_back_old_style_control_message()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Should_send_back_old_style_control_message(bool useAction)
         {
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<EndpointWithLocalCallback>(b => b.When(async (bus, c) =>
                 {
-                    c.Response = await bus.Request<int>(new MyRequest(), new SendOptions());
+                    if (useAction)
+                        c.Response = await bus.Request<MyRequest, int>(x => { }, new SendOptions());
+                    else
+                        c.Response = await bus.Request<int>(new MyRequest(), new SendOptions());
                     c.CallbackFired = true;
                 }))
                 .WithEndpoint<Replier>()

--- a/src/NServiceBus.Callbacks.Tests/API/APIApprovals.ApproveCallbacks.approved.txt
+++ b/src/NServiceBus.Callbacks.Tests/API/APIApprovals.ApproveCallbacks.approved.txt
@@ -10,5 +10,9 @@ namespace NServiceBus
         public static System.Threading.Tasks.Task<TResponse> Request<TResponse>(this NServiceBus.IMessageSession session, object requestMessage, System.Threading.CancellationToken cancellationToken) { }
         public static System.Threading.Tasks.Task<TResponse> Request<TResponse>(this NServiceBus.IMessageSession session, object requestMessage, NServiceBus.SendOptions options) { }
         public static async System.Threading.Tasks.Task<TResponse> Request<TResponse>(this NServiceBus.IMessageSession session, object requestMessage, NServiceBus.SendOptions options, System.Threading.CancellationToken cancellationToken) { }
+        public static System.Threading.Tasks.Task<TResponse> Request<TMessage, TResponse>(this NServiceBus.IMessageSession session, System.Action<TMessage> requestMessage) { }
+        public static System.Threading.Tasks.Task<TResponse> Request<TMessage, TResponse>(this NServiceBus.IMessageSession session, System.Action<TMessage> requestMessage, System.Threading.CancellationToken cancellationToken) { }
+        public static System.Threading.Tasks.Task<TResponse> Request<TMessage, TResponse>(this NServiceBus.IMessageSession session, System.Action<TMessage> requestMessage, NServiceBus.SendOptions options) { }
+        public static async System.Threading.Tasks.Task<TResponse> Request<TMessage, TResponse>(this NServiceBus.IMessageSession session, System.Action<TMessage> requestMessage, NServiceBus.SendOptions options, System.Threading.CancellationToken cancellationToken) { }
     }
 }

--- a/src/NServiceBus.Callbacks/RequestResponseExtensions.cs
+++ b/src/NServiceBus.Callbacks/RequestResponseExtensions.cs
@@ -113,6 +113,112 @@
             }
         }
 
+        /// <summary>
+        /// Sends a <paramref name="requestMessage" /> to the configured destination and returns back a
+        /// <see cref="Task{TResponse}" /> which can be awaited.
+        /// </summary>
+        /// <remarks>
+        /// The task returned is non durable. When the AppDomain is unloaded or the response task is canceled.
+        /// Messages can still arrive to the requesting endpoint but in that case no handling code will be attached to consume
+        /// that response message and therefore the message will be moved to the error queue.
+        /// </remarks>
+        /// <typeparam name="TMessage">The message type.</typeparam>
+        /// <typeparam name="TResponse">The response type.</typeparam>
+        /// <param name="session">The session.</param>
+        /// <param name="requestMessage">The request message constructor.</param>
+        /// <returns>A task which contains the response when it is completed.</returns>
+        public static Task<TResponse> Request<TMessage, TResponse>(this IMessageSession session, Action<TMessage> requestMessage)
+        {
+            return session.Request<TMessage, TResponse>(requestMessage, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Sends a <paramref name="requestMessage" /> to the configured destination and returns back a
+        /// <see cref="Task{TResponse}" /> which can be awaited.
+        /// </summary>
+        /// <remarks>
+        /// The task returned is non durable. When the AppDomain is unloaded or the response task is canceled.
+        /// Messages can still arrive to the requesting endpoint but in that case no handling code will be attached to consume
+        /// that response message and therefore the message will be moved to the error queue.
+        /// </remarks>
+        /// <typeparam name="TMessage">The message type.</typeparam>
+        /// <typeparam name="TResponse">The response type.</typeparam>
+        /// <param name="session">The session.</param>
+        /// <param name="requestMessage">The request message constructor.</param>
+        /// <param name="cancellationToken">The cancellation token used to cancel the request.</param>
+        /// <returns>A task which contains the response when it is completed.</returns>
+        public static Task<TResponse> Request<TMessage, TResponse>(this IMessageSession session, Action<TMessage> requestMessage, CancellationToken cancellationToken)
+        {
+            return session.Request<TMessage, TResponse>(requestMessage, new SendOptions(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Sends a <paramref name="requestMessage" /> to the configured destination and returns back a
+        /// <see cref="Task{TResponse}" /> which can be awaited.
+        /// </summary>
+        /// <remarks>
+        /// The task returned is non durable. When the AppDomain is unloaded or the response task is canceled.
+        /// Messages can still arrive to the requesting endpoint but in that case no handling code will be attached to consume
+        /// that response message and therefore the message will be moved to the error queue.
+        /// </remarks>
+        /// <typeparam name="TMessage">The message type.</typeparam>
+        /// <typeparam name="TResponse">The response type.</typeparam>
+        /// <param name="session">The session.</param>
+        /// <param name="requestMessage">The request message constructor.</param>
+        /// <param name="options">The options for the send.</param>
+        /// <returns>A task which contains the response when it is completed.</returns>
+        public static Task<TResponse> Request<TMessage, TResponse>(this IMessageSession session, Action<TMessage> requestMessage, SendOptions options)
+        {
+            return session.Request<TMessage, TResponse>(requestMessage, options, CancellationToken.None);
+        }
+        /// <summary>
+        /// Sends a <paramref name="requestMessage" /> to the configured destination and returns back a
+        /// <see cref="Task{TResponse}" /> which can be awaited.
+        /// </summary>
+        /// <remarks>
+        /// The task returned is non durable. When the AppDomain is unloaded or the response task is canceled.
+        /// Messages can still arrive to the requesting endpoint but in that case no handling code will be attached to consume
+        /// that response message and therefore the message will be moved to the error queue.
+        /// </remarks>
+        /// <typeparam name="TMessage">The message type.</typeparam>
+        /// <typeparam name="TResponse">The response type.</typeparam>
+        /// <param name="session">The session.</param>
+        /// <param name="requestMessage">The request message constructor.</param>
+        /// <param name="options">The options for the send.</param>
+        /// <param name="cancellationToken">The cancellation token used to cancel the request.</param>
+        /// <returns>A task which contains the response when it is completed.</returns>
+        public static async Task<TResponse> Request<TMessage, TResponse>(this IMessageSession session, Action<TMessage> requestMessage, SendOptions options, CancellationToken cancellationToken)
+        {
+            if (requestMessage == null)
+            {
+                throw new ArgumentNullException(nameof(requestMessage));
+            }
+
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            if (session == null)
+            {
+                throw new ArgumentNullException(nameof(session));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var tcs = new TaskCompletionSource<TResponse>();
+            var adapter = new TaskCompletionSourceAdapter(tcs);
+            options.RouteReplyToThisInstance();
+            options.RegisterCancellationToken(cancellationToken);
+
+            using (options.RegisterTokenSource(adapter))
+            {
+                await session.Send(requestMessage, options).ConfigureAwait(false);
+
+                return await tcs.Task.ConfigureAwait(false);
+            }
+        }
+
 
         static RequestResponseStateLookup.State RegisterTokenSource(this ExtendableOptions options, TaskCompletionSourceAdapter adapter)
         {


### PR DESCRIPTION
I noticed the request method doesn't have support for message constructors like 

```
ctx.Send<MyMessage>(x => {
   x.Foo="Bar";
});
```

Here's a PR to add them in, pretty easy hardest part was updating all the tests - I dont think I did them all right either Im seeing API approval errors and such.  