### PR TITLE
Allowing to disable callbacks or just enable replies

### DIFF
--- a/src/NServiceBus.Callbacks.AcceptanceTests/NServiceBus.Callbacks.AcceptanceTests.csproj
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/NServiceBus.Callbacks.AcceptanceTests.csproj
@@ -84,10 +84,13 @@
     <Compile Include="When_using_callbacks_with_messageid_eq_cid.cs" />
     <Compile Include="When_using_callback_to_get_message.cs" />
     <Compile Include="When_using_callback_to_get_message_canceled.cs" />
+    <Compile Include="When_using_callback_with_reply_only_to_get_message.cs" />
     <Compile Include="When_using_enum_response_and_conventions.cs" />
     <Compile Include="When_using_enum_response.cs" />
+    <Compile Include="When_using_enum_response_with_reply_only.cs" />
     <Compile Include="When_using_int_response_and_conventions.cs" />
     <Compile Include="When_using_int_response.cs" />
+    <Compile Include="When_using_int_response_with_reply_only.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NServiceBus.Callbacks\NServiceBus.Callbacks.csproj">

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_using_callback_with_reply_only_to_get_message.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_using_callback_with_reply_only_to_get_message.cs
@@ -1,0 +1,68 @@
+namespace NServiceBus.AcceptanceTests.Callbacks
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using NUnit.Framework;
+
+    public class When_using_callback_with_reply_only_to_get_message : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_receive_message_and_not_require_uniquely_addressable()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithLocalCallback>(b => b.When(async (bus, c) =>
+                {
+                    c.Response = await bus.Request<MyResponse>(new MyRequest(), new SendOptions());
+                    c.CallbackFired = true;
+                }))
+                .WithEndpoint<Replier>()
+                .Done(c => c.CallbackFired)
+                .Run();
+
+            Assert.IsNotNull(context.Response);
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool CallbackFired { get; set; }
+            public MyResponse Response { get; set; }
+        }
+
+        class Replier : EndpointConfigurationBuilder
+        {
+            public Replier()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                    c.Callbacks().EnableCallbackRepliesOnly());
+            }
+
+            public class MyRequestHandler : IHandleMessages<MyRequest>
+            {
+                public Task Handle(MyRequest message, IMessageHandlerContext context)
+                {
+                    return context.Reply(new MyResponse());
+                }
+            }
+        }
+
+        class EndpointWithLocalCallback : EndpointConfigurationBuilder
+        {
+            public EndpointWithLocalCallback()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                        c.MakeInstanceUniquelyAddressable("1"))
+                    .AddMapping<MyRequest>(typeof(Replier));
+            }
+        }
+
+        public class MyRequest : IMessage
+        {
+        }
+
+        public class MyResponse : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_using_enum_response_with_reply_only.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_using_enum_response_with_reply_only.cs
@@ -1,0 +1,71 @@
+namespace NServiceBus.AcceptanceTests.Callbacks
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using NUnit.Framework;
+
+    public class When_using_enum_response_with_reply_only : NServiceBusAcceptanceTest
+    {
+        public enum OldEnum
+        {
+            Fail,
+            Success
+        }
+
+        [Test]
+        public async Task Should_receive_response_and_not_require_uniquely_addressable()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithLocalCallback>(b => b.When(async (bus, c) =>
+                {
+                    c.Response = await bus.Request<OldEnum>(new MyRequest(), new SendOptions());
+                    c.CallbackFired = true;
+                }))
+                .WithEndpoint<Replier>()
+                .Done(c => c.CallbackFired)
+                .Run();
+
+            Assert.IsNotNull(context.Response);
+            Assert.AreEqual(OldEnum.Success, context.Response);
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool CallbackFired { get; set; }
+            public OldEnum Response { get; set; }
+        }
+
+        class Replier : EndpointConfigurationBuilder
+        {
+            public Replier()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                    c.Callbacks().EnableCallbackRepliesOnly());
+            }
+
+            public class MyRequestHandler : IHandleMessages<MyRequest>
+            {
+                public Task Handle(MyRequest message, IMessageHandlerContext context)
+                {
+                    return context.Reply(OldEnum.Success);
+                }
+            }
+        }
+
+        class EndpointWithLocalCallback : EndpointConfigurationBuilder
+        {
+            public EndpointWithLocalCallback()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                        c.MakeInstanceUniquelyAddressable("1"))
+                    .AddMapping<MyRequest>(typeof(Replier));
+            }
+        }
+
+        public class MyRequest : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_using_int_response_with_reply_only.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_using_int_response_with_reply_only.cs
@@ -1,0 +1,66 @@
+﻿namespace NServiceBus.AcceptanceTests.Callbacks
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using NUnit.Framework;
+
+    public class When_using_int_response_with_reply_only : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_receive_response_and_not_require_uniquely_addressable()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithLocalCallback>(b => b.When(async (bus, c) =>
+                {
+                    c.Response = await bus.Request<int>(new MyRequest(), new SendOptions());
+                    c.CallbackFired = true;
+                }))
+                .WithEndpoint<Replier>()
+                .Done(c => c.CallbackFired)
+                .Run();
+
+            Assert.AreEqual(200, context.Response);
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool CallbackFired { get; set; }
+            public int Response { get; set; }
+        }
+
+        class Replier : EndpointConfigurationBuilder
+        {
+            public Replier()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                    c.Callbacks().EnableCallbackRepliesOnly());
+            }
+
+            public class MyRequestHandler : IHandleMessages<MyRequest>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyRequest message, IMessageHandlerContext context)
+                {
+                    return context.Reply(200);
+                }
+            }
+        }
+
+        class EndpointWithLocalCallback : EndpointConfigurationBuilder
+        {
+            public EndpointWithLocalCallback()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                        c.MakeInstanceUniquelyAddressable("1"))
+                    .AddMapping<MyRequest>(typeof(Replier));
+            }
+        }
+
+        public class MyRequest : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Callbacks.Tests/API/APIApprovals.ApproveCallbacks.approved.txt
+++ b/src/NServiceBus.Callbacks.Tests/API/APIApprovals.ApproveCallbacks.approved.txt
@@ -3,6 +3,18 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute(@"NServiceBus.Callbacks.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100dde965e6172e019ac82c2639ffe494dd2e7dd16347c34762a05732b492e110f2e4e2e1b5ef2d85c848ccfb671ee20a47c8d1376276708dc30a90ff1121b647ba3b7259a6bc383b2034938ef0e275b58b920375ac605076178123693c6c4f1331661a62eba28c249386855637780e3ff5f23a6d854700eaa6803ef48907513b92")]
 [assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.5.2", FrameworkDisplayName=".NET Framework 4.5.2")]
+namespace NServiceBus.Features
+{
+    public class static CallbackExtensions
+    {
+        public static NServiceBus.Features.CallbackSettings Callbacks(this NServiceBus.EndpointConfiguration config) { }
+    }
+    public class CallbackSettings
+    {
+        public void DisableCallbacks() { }
+        public void EnableCallbackRepliesOnly() { }
+    }
+}
 namespace NServiceBus
 {
     public class static RequestResponseExtensions

--- a/src/NServiceBus.Callbacks/CallbackExtensions.cs
+++ b/src/NServiceBus.Callbacks/CallbackExtensions.cs
@@ -1,0 +1,16 @@
+﻿namespace NServiceBus.Features
+{
+    /// <summary>
+    /// Extension methods to configure callbacks on <see cref="EndpointConfiguration"/>.
+    /// </summary>
+    public static class CallbackExtensions
+    {
+        /// <summary>
+        /// Allows to configure callbacks.
+        /// </summary>
+        public static CallbackSettings Callbacks(this EndpointConfiguration config)
+        {
+            return new CallbackSettings(config);
+        }
+    }
+}

--- a/src/NServiceBus.Callbacks/CallbackReplySupport.cs
+++ b/src/NServiceBus.Callbacks/CallbackReplySupport.cs
@@ -1,0 +1,16 @@
+﻿namespace NServiceBus.Features
+{
+    class CallbackReplySupport : Feature
+    {
+        public CallbackReplySupport()
+        {
+            EnableByDefault();
+        }
+
+        protected override void Setup(FeatureConfigurationContext context)
+        {
+            context.Pipeline.Register<SkipBestPracticesForReplyIntEnumBehavior.Registration>();
+            context.Pipeline.Register("SetCallbackResponseReturnCodeBehavior", new SetCallbackResponseReturnCodeBehavior(), "Promotes the callback response return code to a header in order to be backwards compatible with v5 and below");
+        }
+    }
+}

--- a/src/NServiceBus.Callbacks/CallbackRequestSupport.cs
+++ b/src/NServiceBus.Callbacks/CallbackRequestSupport.cs
@@ -2,9 +2,9 @@
 {
     using System;
 
-    class CallbackSupport : Feature
+    class CallbackRequestSupport : Feature
     {
-        public CallbackSupport()
+        public CallbackRequestSupport()
         {
             EnableByDefault();
         }
@@ -20,8 +20,6 @@
             context.Pipeline.Register("RequestResponseInvocationForControlMessagesBehavior", new RequestResponseInvocationForControlMessagesBehavior(lookup), "Invokes the callback of a synchronous request/response for control messages");
             context.Pipeline.Register("RequestResponseInvocationForMessagesBehavior", new RequestResponseInvocationForMessagesBehavior(lookup), "Invokes the callback of a synchronous request/response");
             context.Pipeline.Register(new UpdateRequestResponseCorrelationTableBehavior.Registration(lookup));
-            context.Pipeline.Register("SetCallbackResponseReturnCodeBehavior", new SetCallbackResponseReturnCodeBehavior(), "Promotes the callback response return code to a header in order to be backwards compatible with v5 and below");
-            context.Pipeline.Register<SkipBestPracticesForReplyIntEnumBehavior.Registration>();
         }
     }
 }

--- a/src/NServiceBus.Callbacks/CallbackSettings.cs
+++ b/src/NServiceBus.Callbacks/CallbackSettings.cs
@@ -1,0 +1,33 @@
+﻿namespace NServiceBus.Features
+{
+    /// <summary>
+    /// Callback configuration instance.
+    /// </summary>
+    public class CallbackSettings
+    {
+        internal CallbackSettings(EndpointConfiguration config)
+        {
+            this.config = config;
+        }
+
+        /// <summary>
+        /// Enables the possibility to reply to callbacks without requiring to make the endpoint uniquely
+        /// addressable.
+        /// </summary>
+        public void EnableCallbackRepliesOnly()
+        {
+            config.DisableFeature<CallbackRequestSupport>();
+        }
+
+        /// <summary>
+        /// Disables the callbacks entirely.
+        /// </summary>
+        public void DisableCallbacks()
+        {
+            config.DisableFeature<CallbackRequestSupport>();
+            config.DisableFeature<CallbackReplySupport>();
+        }
+
+        EndpointConfiguration config;
+    }
+}

--- a/src/NServiceBus.Callbacks/NServiceBus.Callbacks.csproj
+++ b/src/NServiceBus.Callbacks/NServiceBus.Callbacks.csproj
@@ -52,9 +52,12 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CallbackExtensions.cs" />
+    <Compile Include="CallbackReplySupport.cs" />
+    <Compile Include="CallbackSettings.cs" />
     <Compile Include="CallbackSupportTypeExtensions.cs" />
     <Compile Include="ExtendableOptionsExtensions.cs" />
-    <Compile Include="CallbackSupport.cs" />
+    <Compile Include="CallbackRequestSupport.cs" />
     <Compile Include="IncomingContextExtensions.cs" />
     <Compile Include="InternalsVisibleTo.cs" />
     <Compile Include="Reply\RequestResponseInvocationForControlMessagesBehavior.cs" />


### PR DESCRIPTION
Would solve #24 and #33 

This is a proposal for the above issues. The idea of this proposal is to allow disabling callbacks entirely or just opt-in for callback replies. When you opt-in for callback replies only then it is not required to make the endpoint uniquely addressable. These changes could be released in a minor. 

Alternatively, we could also do the following:

https://github.com/Particular/NServiceBus.Callbacks/pull/62

