### PR TITLE
Make callback and enum/int support an opt-in decision

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 assembly-versioning-scheme: Major
-next-version: 1.0
+next-version: 2.0
 branches:
   develop:
     tag: alpha

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_a_callback_for_local_message.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_a_callback_for_local_message.cs
@@ -45,7 +45,10 @@ namespace NServiceBus.AcceptanceTests.Callbacks
             public EndpointWithLocalCallback()
             {
                 EndpointSetup<DefaultServer>(c =>
-                    c.MakeInstanceUniquelyAddressable("1"));
+                {
+                    c.MakeInstanceUniquelyAddressable("1");
+                    c.EnableCallbacks();
+                });
             }
 
             public class MyRequestHandler : IHandleMessages<MyRequest>

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_a_callback_for_local_message_canceled.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_a_callback_for_local_message_canceled.cs
@@ -63,7 +63,10 @@ namespace NServiceBus.AcceptanceTests.Callbacks
             public EndpointWithLocalCallback()
             {
                 EndpointSetup<DefaultServer>(c =>
-                    c.MakeInstanceUniquelyAddressable("1"));
+                {
+                    c.MakeInstanceUniquelyAddressable("1");
+                    c.EnableCallbacks();
+                });
             }
 
             public class MyRequestHandler : IHandleMessages<MyRequest>

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_enum_response_canceled.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_enum_response_canceled.cs
@@ -60,8 +60,7 @@
         {
             public Replier()
             {
-                EndpointSetup<DefaultServer>(c =>
-                    c.MakeInstanceUniquelyAddressable("1"));
+                EndpointSetup<DefaultServer>(c => c.EnableCallbacks(makesRequests: false));
             }
 
             public class MyRequestHandler : IHandleMessages<MyRequest>
@@ -83,7 +82,10 @@
             public EndpointWithLocalCallback()
             {
                 EndpointSetup<DefaultServer>(c =>
-                    c.MakeInstanceUniquelyAddressable("1"))
+                    {
+                        c.MakeInstanceUniquelyAddressable("1");
+                        c.EnableCallbacks();
+                    })
                     .AddMapping<MyRequest>(typeof(Replier));
             }
         }

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_int_response_canceled.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_int_response_canceled.cs
@@ -54,8 +54,7 @@ namespace NServiceBus.AcceptanceTests.Callbacks
         {
             public Replier()
             {
-                EndpointSetup<DefaultServer>(c =>
-                    c.MakeInstanceUniquelyAddressable("1"));
+                EndpointSetup<DefaultServer>(c => c.EnableCallbacks(makesRequests: false));
             }
 
             public class MyRequestHandler : IHandleMessages<MyRequest>
@@ -77,7 +76,10 @@ namespace NServiceBus.AcceptanceTests.Callbacks
             public EndpointWithLocalCallback()
             {
                 EndpointSetup<DefaultServer>(c =>
-                    c.MakeInstanceUniquelyAddressable("1"))
+                    {
+                        c.MakeInstanceUniquelyAddressable("1");
+                        c.EnableCallbacks();
+                    })
                     .AddMapping<MyRequest>(typeof(Replier));
             }
         }

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_using_callback_to_get_message.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_using_callback_to_get_message.cs
@@ -33,8 +33,7 @@
         {
             public Replier()
             {
-                EndpointSetup<DefaultServer>(c =>
-                    c.MakeInstanceUniquelyAddressable("1"));
+                EndpointSetup<DefaultServer>();
             }
 
             public class MyRequestHandler : IHandleMessages<MyRequest>
@@ -51,7 +50,10 @@
             public EndpointWithLocalCallback()
             {
                 EndpointSetup<DefaultServer>(c =>
-                    c.MakeInstanceUniquelyAddressable("1"))
+                    {
+                        c.MakeInstanceUniquelyAddressable("1");
+                        c.EnableCallbacks();
+                    })
                     .AddMapping<MyRequest>(typeof(Replier));
             }
         }

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_using_callback_to_get_message_canceled.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_using_callback_to_get_message_canceled.cs
@@ -57,8 +57,7 @@
         {
             public Replier()
             {
-                EndpointSetup<DefaultServer>(c =>
-                    c.MakeInstanceUniquelyAddressable("1"));
+                EndpointSetup<DefaultServer>();
             }
 
             public class MyRequestHandler : IHandleMessages<MyRequest>
@@ -80,7 +79,10 @@
             public EndpointWithLocalCallback()
             {
                 EndpointSetup<DefaultServer>(c =>
-                    c.MakeInstanceUniquelyAddressable("1"))
+                    {
+                        c.MakeInstanceUniquelyAddressable("1");
+                        c.EnableCallbacks();
+                    })
                     .AddMapping<MyRequest>(typeof(Replier));
             }
         }

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_using_callbacks_in_a_scaleout.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_using_callbacks_in_a_scaleout.cs
@@ -64,8 +64,7 @@
         {
             public Client()
             {
-                EndpointSetup<DefaultServer>(c =>
-                    c.MakeInstanceUniquelyAddressable("1"))
+                EndpointSetup<DefaultServer>(c => c.EnableCallbacks())
                     .AddMapping<MyRequest>(typeof(Server));
             }
         }
@@ -74,8 +73,7 @@
         {
             public Server()
             {
-                EndpointSetup<DefaultServer>(c =>
-                    c.MakeInstanceUniquelyAddressable("1"));
+                EndpointSetup<DefaultServer>();
             }
 
             public class MyMessageHandler : IHandleMessages<MyRequest>

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_using_callbacks_with_messageid_eq_cid.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_using_callbacks_with_messageid_eq_cid.cs
@@ -40,7 +40,10 @@
             public EndpointWithLocalCallback()
             {
                 EndpointSetup<DefaultServer>(c =>
-                    c.MakeInstanceUniquelyAddressable("1"));
+                {
+                    c.MakeInstanceUniquelyAddressable("1");
+                    c.EnableCallbacks();
+                });
             }
 
             public class MyRequestHandler : IHandleMessages<MyRequest>

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_using_enum_response.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_using_enum_response.cs
@@ -40,8 +40,7 @@
         {
             public Replier()
             {
-                EndpointSetup<DefaultServer>(c =>
-                    c.MakeInstanceUniquelyAddressable("1"));
+                EndpointSetup<DefaultServer>(c => c.EnableCallbacks(makesRequests: false));
             }
 
             public class MyRequestHandler : IHandleMessages<MyRequest>
@@ -58,7 +57,10 @@
             public EndpointWithLocalCallback()
             {
                 EndpointSetup<DefaultServer>(c =>
-                    c.MakeInstanceUniquelyAddressable("1"))
+                    {
+                        c.MakeInstanceUniquelyAddressable("1");
+                        c.EnableCallbacks();
+                    })
                     .AddMapping<MyRequest>(typeof(Replier));
             }
         }

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_using_enum_response_and_conventions.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_using_enum_response_and_conventions.cs
@@ -45,7 +45,7 @@
                 {
                     var conventions = c.Conventions();
                     conventions.DefiningCommandsAs(DefinesCommandType);
-                    c.MakeInstanceUniquelyAddressable("1");
+                    c.EnableCallbacks(makesRequests: false);
                 });
             }
 
@@ -68,7 +68,10 @@
             public EndpointWithLocalCallback()
             {
                 EndpointSetup<DefaultServer>(c =>
-                    c.MakeInstanceUniquelyAddressable("1"))
+                    {
+                        c.MakeInstanceUniquelyAddressable("1");
+                        c.EnableCallbacks();
+                    })
                     .AddMapping<MyRequest>(typeof(Replier));
             }
         }

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_using_int_response.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_using_int_response.cs
@@ -33,8 +33,7 @@
         {
             public Replier()
             {
-                EndpointSetup<DefaultServer>(c =>
-                    c.MakeInstanceUniquelyAddressable("1"));
+                EndpointSetup<DefaultServer>(c => c.EnableCallbacks(makesRequests: false));
             }
 
             public class MyRequestHandler : IHandleMessages<MyRequest>
@@ -53,7 +52,10 @@
             public EndpointWithLocalCallback()
             {
                 EndpointSetup<DefaultServer>(c =>
-                    c.MakeInstanceUniquelyAddressable("1"))
+                    {
+                        c.MakeInstanceUniquelyAddressable("1");
+                        c.EnableCallbacks();
+                    })
                     .AddMapping<MyRequest>(typeof(Replier));
             }
         }

--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_using_int_response_and_conventions.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_using_int_response_and_conventions.cs
@@ -38,7 +38,7 @@
                 {
                     var conventions = c.Conventions();
                     conventions.DefiningCommandsAs(DefinesCommandType);
-                    c.MakeInstanceUniquelyAddressable("1");
+                    c.EnableCallbacks(makesRequests: false);
                 });
             }
 
@@ -61,7 +61,10 @@
             public EndpointWithLocalCallback()
             {
                 EndpointSetup<DefaultServer>(c =>
-                    c.MakeInstanceUniquelyAddressable("1"))
+                    {
+                        c.MakeInstanceUniquelyAddressable("1");
+                        c.EnableCallbacks();
+                    })
                     .AddMapping<MyRequest>(typeof(Replier));
             }
         }

--- a/src/NServiceBus.Callbacks.Tests/API/APIApprovals.ApproveCallbacks.approved.txt
+++ b/src/NServiceBus.Callbacks.Tests/API/APIApprovals.ApproveCallbacks.approved.txt
@@ -5,6 +5,10 @@
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.5.2", FrameworkDisplayName=".NET Framework 4.5.2")]
 namespace NServiceBus
 {
+    public class static CallbackExtensions
+    {
+        public static void EnableCallbacks(this NServiceBus.EndpointConfiguration config, bool makesRequests = True) { }
+    }
     public class static RequestResponseExtensions
     {
         public static System.Threading.Tasks.Task<TResponse> Request<TResponse>(this NServiceBus.IMessageSession session, object requestMessage) { }

--- a/src/NServiceBus.Callbacks/CallbackExtensions.cs
+++ b/src/NServiceBus.Callbacks/CallbackExtensions.cs
@@ -1,0 +1,31 @@
+﻿namespace NServiceBus
+{
+    using Features;
+
+    /// <summary>
+    /// Extension methods to configure callbacks on <see cref="EndpointConfiguration" />.
+    /// </summary>
+    public static class CallbackExtensions
+    {
+        /// <summary>
+        /// Enables the callbacks feature.
+        /// </summary>
+        /// <param name="config">The endpoint configuration.</param>
+        /// <param name="makesRequests">
+        /// The value that indicates whether the endpoint can make callback requests. If <c>true</c>, the endpoint must be uniquely
+        /// addressable.
+        /// </param>
+        public static void EnableCallbacks(this EndpointConfiguration config, bool makesRequests = true)
+        {
+            if (makesRequests)
+            {
+                config.EnableFeature<CallbackRequestSupport>();
+                config.EnableFeature<CallbackReplySupport>();
+            }
+            else
+            {
+                config.EnableFeature<CallbackReplySupport>();
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Callbacks/CallbackReplySupport.cs
+++ b/src/NServiceBus.Callbacks/CallbackReplySupport.cs
@@ -1,0 +1,11 @@
+﻿namespace NServiceBus.Features
+{
+    class CallbackReplySupport : Feature
+    {
+        protected override void Setup(FeatureConfigurationContext context)
+        {
+            context.Pipeline.Register<SkipBestPracticesForReplyIntEnumBehavior.Registration>();
+            context.Pipeline.Register("SetCallbackResponseReturnCodeBehavior", new SetCallbackResponseReturnCodeBehavior(), "Promotes the callback response return code to a header in order to be backwards compatible with v5 and below");
+        }
+    }
+}

--- a/src/NServiceBus.Callbacks/CallbackRequestSupport.cs
+++ b/src/NServiceBus.Callbacks/CallbackRequestSupport.cs
@@ -2,13 +2,8 @@
 {
     using System;
 
-    class CallbackSupport : Feature
+    class CallbackRequestSupport : Feature
     {
-        public CallbackSupport()
-        {
-            EnableByDefault();
-        }
-
         protected override void Setup(FeatureConfigurationContext context)
         {
             if (!context.Settings.HasSetting("EndpointInstanceDiscriminator"))
@@ -20,8 +15,6 @@
             context.Pipeline.Register("RequestResponseInvocationForControlMessagesBehavior", new RequestResponseInvocationForControlMessagesBehavior(lookup), "Invokes the callback of a synchronous request/response for control messages");
             context.Pipeline.Register("RequestResponseInvocationForMessagesBehavior", new RequestResponseInvocationForMessagesBehavior(lookup), "Invokes the callback of a synchronous request/response");
             context.Pipeline.Register(new UpdateRequestResponseCorrelationTableBehavior.Registration(lookup));
-            context.Pipeline.Register("SetCallbackResponseReturnCodeBehavior", new SetCallbackResponseReturnCodeBehavior(), "Promotes the callback response return code to a header in order to be backwards compatible with v5 and below");
-            context.Pipeline.Register<SkipBestPracticesForReplyIntEnumBehavior.Registration>();
         }
     }
 }

--- a/src/NServiceBus.Callbacks/NServiceBus.Callbacks.csproj
+++ b/src/NServiceBus.Callbacks/NServiceBus.Callbacks.csproj
@@ -52,9 +52,11 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CallbackExtensions.cs" />
+    <Compile Include="CallbackReplySupport.cs" />
     <Compile Include="CallbackSupportTypeExtensions.cs" />
     <Compile Include="ExtendableOptionsExtensions.cs" />
-    <Compile Include="CallbackSupport.cs" />
+    <Compile Include="CallbackRequestSupport.cs" />
     <Compile Include="IncomingContextExtensions.cs" />
     <Compile Include="InternalsVisibleTo.cs" />
     <Compile Include="Reply\RequestResponseInvocationForControlMessagesBehavior.cs" />


### PR DESCRIPTION
Alternative to #61 

* Bumps develop to 2.0
* Makes the callbacks opt-in
* Allows using callbacks in `makesRequests: false` mode
* Doco PR https://github.com/Particular/docs.particular.net/pull/2707

## Enable callbacks

```
endpointConfig.EnableCallbacks();
```

The endpoint has to be uniquely addressable. The endpoint can use callbacks with the request extension and reply with ints, enums and objects

## Makes requests `false`
```
endpointConfig.EnableCallbacks(makesRequests: false);
```

The endpoint doesn't require to be uniquely addressable. The endpoint can only reply to callbacks with int, enums and objects.

## No reference to callbacks

Endpoints can always reply to object callbacks (was before also the case, just mentioning here for completeness)