### PR TITLE
When a sender version is less than 5.0 do not check the message intent

### DIFF
--- a/src/NServiceBus.Callbacks.Tests/When_sending_reply_to_the_request.cs
+++ b/src/NServiceBus.Callbacks.Tests/When_sending_reply_to_the_request.cs
@@ -7,16 +7,24 @@
     using Transport;
 
     [TestFixture]
-    class When_sending_reply_to_the_request
+    public class When_sending_reply_to_the_request
     {
+        [TestCase("6.0.0", MessageIntentEnum.Reply, true)]
+        [TestCase("6.0.0", MessageIntentEnum.Send, false)]
+        [TestCase("6.0.0", MessageIntentEnum.Publish, false)]
+        [TestCase("6.0.0", MessageIntentEnum.Subscribe, false)]
+        [TestCase("6.0.0", MessageIntentEnum.Unsubscribe, false)]
         [TestCase("5.0.0", MessageIntentEnum.Reply, true)]
         [TestCase("5.0.0", MessageIntentEnum.Send, false)]
-        [TestCase("4.3.0", MessageIntentEnum.Reply, true)]
-        [TestCase("4.3.0", MessageIntentEnum.Send, false)]
-        [TestCase("4.3.0", MessageIntentEnum.Publish, false)]
-        [TestCase("4.3.0", MessageIntentEnum.Subscribe, false)]
-        [TestCase("4.3.0", MessageIntentEnum.Unsubscribe, false)]
-        public void From_v4_3_0_should_return_value_only_for_reply_intent(string nsbVersion, MessageIntentEnum intent, bool expectedNonEmptyResult)
+        [TestCase("5.0.0", MessageIntentEnum.Publish, false)]
+        [TestCase("5.0.0", MessageIntentEnum.Subscribe, false)]
+        [TestCase("5.0.0", MessageIntentEnum.Unsubscribe, false)]
+        [TestCase("4.7.0", MessageIntentEnum.Reply, true)]
+        [TestCase("4.7.0", MessageIntentEnum.Send, true)]
+        [TestCase("4.7.0", MessageIntentEnum.Publish, true)]
+        [TestCase("4.7.0", MessageIntentEnum.Subscribe, true)]
+        [TestCase("4.7.0", MessageIntentEnum.Unsubscribe, true)]
+        public void From_v5_0_0_should_return_value_only_for_reply_intent(string nsbVersion, MessageIntentEnum intent, bool expectedNonEmptyResult)
         {
             var correlationId = new Guid().ToString();
             var lookup = new RequestResponseStateLookup();
@@ -30,6 +38,11 @@
             Assert.AreEqual(expectedNonEmptyResult, result.HasValue);
         }
 
+        [TestCase("4.7.12", MessageIntentEnum.Reply)]
+        [TestCase("4.7.12", MessageIntentEnum.Send)]
+        [TestCase("4.7.12", MessageIntentEnum.Publish)]
+        [TestCase("4.7.12", MessageIntentEnum.Subscribe)]
+        [TestCase("4.7.12", MessageIntentEnum.Unsubscribe)]
         [TestCase("4.2.9", MessageIntentEnum.Reply)]
         [TestCase("4.2.9", MessageIntentEnum.Send)]
         [TestCase("4.2.9", MessageIntentEnum.Publish)]
@@ -39,7 +52,7 @@
         [TestCase("4.1.0", MessageIntentEnum.Send)]
         [TestCase("3.0.0", MessageIntentEnum.Reply)]
         [TestCase("3.0.0", MessageIntentEnum.Publish)]
-        public void Below_v4_3_0_should_return_value_for_all_intents(string nsbVersion, MessageIntentEnum intent)
+        public void Below_v5_0_0_should_return_value_for_all_intents(string nsbVersion, MessageIntentEnum intent)
         {
             var correlationId = new Guid().ToString();
             var lookup = new RequestResponseStateLookup();

--- a/src/NServiceBus.Callbacks/IncomingContextExtensions.cs
+++ b/src/NServiceBus.Callbacks/IncomingContextExtensions.cs
@@ -46,6 +46,6 @@ namespace NServiceBus
             return context.MessageHeaders.TryGetValue(Headers.CorrelationId, out str) ? str : null;
         }
 
-        static Version minimumVersionThatSupportMessageIntent_Reply = new Version(4, 3);
+        static Version minimumVersionThatSupportMessageIntent_Reply = new Version(5, 0);
     }
 }


### PR DESCRIPTION
Fixes #67 

[More details](https://github.com/Particular/NServiceBus.Callbacks/issues/66#issuecomment-312797501)