### PR TITLE
Update NServiceBus to 7.0.0-beta0012 and Testing to 7.0.0-beta0004

### DIFF
--- a/src/NServiceBus.Callback.Testing.Tests/NServiceBus.Callback.Testing.Tests.csproj
+++ b/src/NServiceBus.Callback.Testing.Tests/NServiceBus.Callback.Testing.Tests.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="ApprovalTests" Version="3.0.13" NoWarn="NU1701" />
     <PackageReference Include="ApprovalUtilities" Version="3.0.13" NoWarn="NU1701" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="NServiceBus" Version="7.0.0-*" />
-    <PackageReference Include="NServiceBus.Testing" Version="7.0.0-*" />
+    <PackageReference Include="NServiceBus" Version="7.0.0-beta0012" />
+    <PackageReference Include="NServiceBus.Testing" Version="7.0.0-beta0004" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
   </ItemGroup>

--- a/src/NServiceBus.Callbacks.AcceptanceTests/NServiceBus.Callbacks.AcceptanceTests.csproj
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/NServiceBus.Callbacks.AcceptanceTests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.0.0-*" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.0.0-beta0012" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
   </ItemGroup>

--- a/src/NServiceBus.Callbacks.Testing/NServiceBus.Callbacks.Testing.csproj
+++ b/src/NServiceBus.Callbacks.Testing/NServiceBus.Callbacks.Testing.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Testing" Version="7.0.0-*" />
+    <PackageReference Include="NServiceBus.Testing" Version="[7.0.0-beta0004, 8.0.0)" />
     <PackageReference Include="Particular.Packaging" Version="0.1.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/NServiceBus.Callbacks.Tests/NServiceBus.Callbacks.Tests.csproj
+++ b/src/NServiceBus.Callbacks.Tests/NServiceBus.Callbacks.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="ApprovalTests" Version="3.0.13" NoWarn="NU1701" />
     <PackageReference Include="ApprovalUtilities" Version="3.0.13" NoWarn="NU1701" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="NServiceBus" Version="7.0.0-*" />
+    <PackageReference Include="NServiceBus" Version="7.0.0-beta0012" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
   </ItemGroup>

--- a/src/NServiceBus.Callbacks/NServiceBus.Callbacks.csproj
+++ b/src/NServiceBus.Callbacks/NServiceBus.Callbacks.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="7.0.0-*" />
+    <PackageReference Include="NServiceBus" Version="[7.0.0-beta0012, 8.0.0)" />
     <PackageReference Include="Particular.Packaging" Version="0.1.0" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
This updates to the latest beta packages, removing the wildcards in the process. This lets us specify a version range for the package.