### PR TITLE
Avoid race condition in cancellation test

### DIFF
--- a/src/NServiceBus.Callbacks.AcceptanceTests/When_using_callback_to_get_message_canceled.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/When_using_callback_to_get_message_canceled.cs
@@ -32,12 +32,12 @@
                         exception = e;
                     }
                 }))
-                .Done(c => exception != null)
+                .Done(c => c.GotTheResponseMessage)
                 .Run();
 
-            Assert.IsNull(context.Response);
+            Assert.True(context.GotTheResponseMessage);
             Assert.False(context.CallbackFired);
-            Assert.True(context.HandlerGotTheRequest);
+            Assert.IsNull(context.Response);
             Assert.IsInstanceOf<OperationCanceledException>(exception);
         }
 
@@ -45,11 +45,11 @@
         {
             public CancellationTokenSource TokenSource { get; set; }
 
-            public bool HandlerGotTheRequest { get; set; }
-
             public bool CallbackFired { get; set; }
 
             public MyResponse Response { get; set; }
+
+            public bool GotTheResponseMessage { get; set; }
         }
 
         class Replier : EndpointConfigurationBuilder
@@ -65,7 +65,6 @@
 
                 public Task Handle(MyRequest message, IMessageHandlerContext context)
                 {
-                    Context.HandlerGotTheRequest = true;
                     Context.TokenSource.Cancel();
 
                     return context.Reply(new MyResponse());
@@ -83,6 +82,18 @@
                     c.EnableCallbacks();
                     c.ConfigureTransport().Routing().RouteToEndpoint(typeof(MyRequest), typeof(Replier));
                 });
+            }
+
+            public class MyResponseHandler : IHandleMessages<MyResponse>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyResponse message, IMessageHandlerContext context)
+                {
+                    Context.GotTheResponseMessage = true;
+
+                    return Task.FromResult(0);
+                }
             }
         }
 


### PR DESCRIPTION
This fixes the intermittent test failures on the release branch. Turned out that we had 1 more test that had the same issues as the one fixed in #85 