### PR TITLE
[Repro] blocking callbacks

### DIFF
--- a/src/NServiceBus.Callbacks.Tests/TaskCompletionSourceAdapterTests.cs
+++ b/src/NServiceBus.Callbacks.Tests/TaskCompletionSourceAdapterTests.cs
@@ -1,0 +1,57 @@
+﻿namespace NServiceBus.Callbacks.Tests
+{
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class TaskCompletionSourceAdapterTests
+    {
+        [Test]
+        public async Task ShouldSetResultNonBlocking()
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            var adapter = new TaskCompletionSourceAdapter<bool>(tcs);
+
+            var @continue = false;
+            // simulate code handling the callback response after await endpoint.Request<Response>(...);
+            var result = tcs.Task.ContinueWith(_ =>
+            {
+                // ReSharper disable once AccessToModifiedClosure
+                while (!@continue)
+                {
+                    // spin
+                }
+            }, TaskContinuationOptions.ExecuteSynchronously);
+            
+            adapter.TrySetResult(true);
+            // TrySetResult should continue immediately
+            @continue = true;
+
+            await result;
+        }
+
+        [Test]
+        public async Task ShouldSetCanceledNonBlocking()
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            var adapter = new TaskCompletionSourceAdapter<bool>(tcs);
+
+            var @continue = false;
+            // simulate code handling the callback response after await endpoint.Request<Response>(...);
+            var result = tcs.Task.ContinueWith(_ =>
+            {
+                // ReSharper disable once AccessToModifiedClosure
+                while (!@continue)
+                {
+                    // spin
+                }
+            }, TaskContinuationOptions.ExecuteSynchronously);
+
+            adapter.TrySetCanceled();
+            // TrySetCanceled should continue immediately
+            @continue = true;
+
+            await result;
+        }
+    }
+}

--- a/src/NServiceBus.Callbacks/TaskCompletionSourceAdapter.cs
+++ b/src/NServiceBus.Callbacks/TaskCompletionSourceAdapter.cs
@@ -26,12 +26,12 @@ namespace NServiceBus
 
         public void TrySetResult(object result)
         {
-            taskCompletionSource.TrySetResult((TResult) result);
+            Task.Run(() => taskCompletionSource.TrySetResult((TResult) result));
         }
 
         public void TrySetCanceled()
         {
-            taskCompletionSource.TrySetCanceled();
+            Task.Run(() => taskCompletionSource.TrySetCanceled());
         }
     }
 }


### PR DESCRIPTION
Callbacks are invoked in a blocking manner from the pipeline. Depending on the user code after awaiting the callback response, this can delay or mess up the pipeline completeley.

E.g. in the following scenario, a callback is sent to a endpoint which also has a message handler for the response message. The handler invocation is always delayed until the next callback is invoked as the pipeline is blocked at the `await` in the next iteration of the while loop:

            while (true)
            {
                var k = Console.ReadKey();
                if (k.Key == ConsoleKey.Enter)
                {
                    var response = await endpoint.Request<Response>(new Request() {Message = Guid.NewGuid().ToString("D")});
                    Console.WriteLine($"Handling callback: {response.Message}");
                    
                    //workaround:
                    //await Task.Yield();
                }
                [...]
            }

as the sample shows, the pipeline is blocked until the next await. e.g. a Task.Yield can free the pipeline and allow the pipeline to continue to process the message.

