### PR TITLE
[WIP] Add async analyzer test cases for callbacks API

### DIFF
--- a/src/NServiceBus.Callbacks.AnalyzerTests/AwaitOrCaptureTasksAnalyzerTests.cs
+++ b/src/NServiceBus.Callbacks.AnalyzerTests/AwaitOrCaptureTasksAnalyzerTests.cs
@@ -1,0 +1,117 @@
+﻿namespace NServiceBus.Core.Analyzer.Tests
+{
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using Helpers;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class AwaitOrCaptureTasksAnalyzerTests : DiagnosticVerifier
+    {
+        // IPipelineContext
+        [TestCase("IPipelineContext", "obj.Send(new object(), new SendOptions());")]
+
+        // Callbacks extensions
+        [TestCase("IMessageSession", "obj.Request<object>(new object());")]
+        [TestCase("IMessageSession", "obj.Request<object>(new object(), CancellationToken.None);")]
+        [TestCase("IMessageSession", "obj.Request<object>(new object(), new SendOptions());")]
+        [TestCase("IMessageSession", "obj.Request<object>(new object(), new SendOptions(), CancellationToken.None);")]
+        
+        public async Task DiagnosticIsReported(string type, string call)
+        {
+            var source =
+$@"using NServiceBus;
+using System.Threading;
+public class Foo
+{{
+    public void Bar({type} obj)
+    {{
+        {call}
+    }}
+}}";
+
+            var expected = new DiagnosticResult
+            {
+                Id = "NSB0001",
+                Message = "Expression calling an NServiceBus method creates a Task that is not awaited or assigned to a variable.",
+                Severity = DiagnosticSeverity.Error,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 7, 9) },
+            };
+
+            await Verify(source, expected);
+        }
+
+        [Test]
+        public async Task DiagnosticsIsReportedForAsyncMethods()
+        {
+            var source =
+@"using NServiceBus;
+public class Foo
+{
+    public async Task Bar(IMessageSession session)
+    {
+        session.Request<object>(new object());
+    }
+}";
+
+            var expected = new DiagnosticResult
+            {
+                Id = "NSB0001",
+                Message = "Expression calling an NServiceBus method creates a Task that is not awaited or assigned to a variable.",
+                Severity = DiagnosticSeverity.Error,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 9) },
+            };
+
+            await Verify(source, expected);
+        }
+
+        [TestCase("")]
+        [TestCase(
+            @"using NServiceBus;
+public class Foo
+{
+    public async Task Bar(IMessageSession session)
+    {
+        await session.Request<object>(new object());
+    }
+}")]
+        [TestCase(
+            @"using NServiceBus;
+public class Foo
+{
+    public Task Bar(IMessageSession session) =>
+        session.Request<object>(new object());
+}")]
+        [TestCase(
+            @"using NServiceBus;
+public class Foo
+{
+    public Task Bar(IMessageSession session)
+    {
+        session.Request<object>(new object()).GetAwaiter().GetResult();
+    }
+}")]
+        [TestCase(
+            @"using NServiceBus;
+public class Foo
+{
+    public Task Bar(IMessageSession session)
+    {
+        session.Request<object>(new object()).Wait();
+    }
+}")]
+        [TestCase(
+            @"using NServiceBus;
+public class Foo
+{
+    public Task Bar(IMessageSession session)
+    {
+        session.Request<object>(new object()).ConfigureAwait(false);
+    }
+}")]
+        public async Task NoDiagnosticIsReported(string source) => await Verify(source);
+
+        protected override DiagnosticAnalyzer GetAnalyzer() => new AwaitOrCaptureTasksAnalyzer();
+    }
+}

--- a/src/NServiceBus.Callbacks.AnalyzerTests/Helpers/DiagnosticResult.cs
+++ b/src/NServiceBus.Callbacks.AnalyzerTests/Helpers/DiagnosticResult.cs
@@ -1,0 +1,21 @@
+namespace NServiceBus.Core.Analyzer.Tests.Helpers
+{
+    using Microsoft.CodeAnalysis;
+
+    public class DiagnosticResult
+    {
+        public DiagnosticResultLocation[] Locations { get; set; }
+
+        public DiagnosticSeverity Severity { get; set; }
+
+        public string Id { get; set; }
+
+        public string Message { get; set; }
+
+        public string Path => this.Locations?.Length > 0 ? this.Locations[0].Path : "";
+
+        public int Line => this.Locations?.Length > 0 ? this.Locations[0].Line : -1;
+
+        public int Column => this.Locations?.Length > 0 ? this.Locations[0].Character : -1;
+    }
+}

--- a/src/NServiceBus.Callbacks.AnalyzerTests/Helpers/DiagnosticResultLocation.cs
+++ b/src/NServiceBus.Callbacks.AnalyzerTests/Helpers/DiagnosticResultLocation.cs
@@ -1,0 +1,30 @@
+namespace NServiceBus.Core.Analyzer.Tests.Helpers
+{
+    using System;
+
+    public struct DiagnosticResultLocation
+    {
+        public DiagnosticResultLocation(string path, int line, int character)
+        {
+            if (line < -1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(line), "line must be >= -1");
+            }
+
+            if (character < -1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(character), "character must be >= -1");
+            }
+
+            this.Path = path;
+            this.Line = line;
+            this.Character = character;
+        }
+
+        public string Path { get; }
+
+        public int Line { get; }
+
+        public int Character { get; }
+    }
+}

--- a/src/NServiceBus.Callbacks.AnalyzerTests/Helpers/DiagnosticVerifier.cs
+++ b/src/NServiceBus.Callbacks.AnalyzerTests/Helpers/DiagnosticVerifier.cs
@@ -1,0 +1,247 @@
+namespace NServiceBus.Core.Analyzer.Tests.Helpers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using Microsoft.CodeAnalysis.Text;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Base type for tests for DiagnosticAnalyzers
+    /// </summary>
+    public abstract class DiagnosticVerifier
+    {
+        static readonly MetadataReference CorlibReference = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
+        static readonly MetadataReference SystemCoreReference = MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location);
+        static readonly MetadataReference CSharpSymbolsReference = MetadataReference.CreateFromFile(typeof(CSharpCompilation).Assembly.Location);
+        static readonly MetadataReference CodeAnalysisReference = MetadataReference.CreateFromFile(typeof(Compilation).Assembly.Location);
+        static readonly MetadataReference NServiceBusReference = MetadataReference.CreateFromFile(typeof(EndpointConfiguration).Assembly.Location);
+        static readonly MetadataReference CallbacksReference = MetadataReference.CreateFromFile(typeof(CallbackExtensions).Assembly.Location);
+
+        /// <summary>
+        /// Get the analyzer being tested.
+        /// </summary>
+        protected abstract DiagnosticAnalyzer GetAnalyzer();
+
+        /// <summary>
+        /// Called to test a DiagnosticAnalyzer when applied on the single inputted string as a source
+        /// Note: input a DiagnosticResult for each Diagnostic expected
+        /// </summary>
+        /// <param name="source">A class in the form of a string to run the analyzer on</param>
+        /// <param name="expectedResults"> DiagnosticResults that should appear after the analyzer is run on the source</param>
+        protected Task Verify(string source, params DiagnosticResult[] expectedResults) => Verify(new[] { source }, expectedResults);
+
+        /// <summary>
+        /// Called to test a DiagnosticAnalyzer when applied on the inputted strings as a source
+        /// Note: input a DiagnosticResult for each Diagnostic expected
+        /// </summary>
+        /// <param name="sources">An array of strings to create source documents from to run the analyzers on</param>
+        /// <param name="expectedResults">DiagnosticResults that should appear after the analyzer is run on the sources</param>
+        protected async Task Verify(string[] sources, params DiagnosticResult[] expectedResults)
+        {
+            var analyzer = GetAnalyzer();
+
+            var actualResults = await GetSortedDiagnostics(sources, analyzer);
+
+            var expectedCount = expectedResults.Length;
+            var actualCount = actualResults.Length;
+
+            if (expectedCount != actualCount)
+            {
+                var diagnosticsOutput = actualResults.Any() ? FormatDiagnostics(analyzer, actualResults.ToArray()) : "    NONE.";
+
+                Assert.Fail($"Mismatch between number of diagnostics returned, expected \"{expectedCount}\" actual \"{actualCount}\"\r\n\r\nDiagnostics:\r\n{diagnosticsOutput}\r\n");
+            }
+
+            for (var expectedResultIndex = 0; expectedResultIndex < expectedResults.Length; expectedResultIndex++)
+            {
+                var actual = actualResults.ElementAt(expectedResultIndex);
+                var expected = expectedResults[expectedResultIndex];
+
+                if (expected.Line == -1 && expected.Column == -1)
+                {
+                    if (actual.Location != Location.None)
+                    {
+                        Assert.Fail($"Expected:\nA project diagnostic with no location\nActual:\n{FormatDiagnostics(analyzer, actual)}");
+                    }
+                }
+                else
+                {
+                    VerifyDiagnosticLocation(analyzer, actual, actual.Location, expected.Locations.First());
+
+                    var additionalLocations = actual.AdditionalLocations.ToArray();
+
+                    if (additionalLocations.Length != expected.Locations.Length - 1)
+                    {
+                        Assert.Fail($"Expected {expected.Locations.Length - 1} additional locations but got {additionalLocations.Length} for Diagnostic:\r\n    {FormatDiagnostics(analyzer, actual)}\r\n");
+                    }
+
+                    for (var additionalLocationIndex = 0; additionalLocationIndex < additionalLocations.Length; ++additionalLocationIndex)
+                    {
+                        VerifyDiagnosticLocation(analyzer, actual, additionalLocations[additionalLocationIndex], expected.Locations[additionalLocationIndex + 1]);
+                    }
+                }
+
+                if (actual.Id != expected.Id)
+                {
+                    Assert.Fail($"Expected diagnostic id to be \"{expected.Id}\" was \"{actual.Id}\"\r\n\r\nDiagnostic:\r\n    {FormatDiagnostics(analyzer, actual)}\r\n");
+                }
+
+                if (actual.Severity != expected.Severity)
+                {
+                    Assert.Fail($"Expected diagnostic severity to be \"{expected.Severity}\" was \"{actual.Severity}\"\r\n\r\nDiagnostic:\r\n    {FormatDiagnostics(analyzer, actual)}\r\n");
+                }
+
+                var actualMessage = actual.GetMessage();
+                if (actualMessage != expected.Message)
+                {
+                    Assert.Fail($"Expected diagnostic message to be \"{expected.Message}\" was \"{actualMessage}\"\r\n\r\nDiagnostic:\r\n    {FormatDiagnostics(analyzer, actual)}\r\n");
+                }
+            }
+        }
+
+        static void VerifyDiagnosticLocation(DiagnosticAnalyzer analyzer, Diagnostic diagnostic, Location actual, DiagnosticResultLocation expected)
+        {
+            var actualSpan = actual.GetLineSpan();
+
+            Assert.IsTrue(
+                actualSpan.Path == expected.Path || (actualSpan.Path != null && actualSpan.Path.Contains("Test0.") && expected.Path.Contains("Test.")),
+                $"Expected diagnostic to be in file \"{expected.Path}\" was actually in file \"{actualSpan.Path}\"\r\n\r\nDiagnostic:\r\n    {FormatDiagnostics(analyzer, diagnostic)}\r\n");
+
+            var actualPosition = actualSpan.StartLinePosition;
+
+            // Only check line position if there is an actual line in the real diagnostic
+            if (actualPosition.Line > 0 && actualPosition.Line + 1 != expected.Line)
+            {
+                Assert.Fail($"Expected diagnostic to be on line \"{expected.Line}\" was actually on line \"{actualPosition.Line + 1}\"\r\n\r\nDiagnostic:\r\n    {FormatDiagnostics(analyzer, diagnostic)}\r\n");
+            }
+
+            // Only check character position if there is an actual character position in the real diagnostic
+            if (actualPosition.Character > 0 && actualPosition.Character + 1 != expected.Character)
+            {
+                Assert.Fail($"Expected diagnostic to start at character \"{expected.Character}\" was actually at character \"{actualPosition.Character + 1}\"\r\n\r\nDiagnostic:\r\n    {FormatDiagnostics(analyzer, diagnostic)}\r\n");
+            }
+        }
+
+        static async Task<Diagnostic[]> GetSortedDiagnostics(string[] sources, DiagnosticAnalyzer analyzer)
+        {
+            var projectId = ProjectId.CreateNewId("TestProject");
+
+            var solution = new AdhocWorkspace()
+                .CurrentSolution
+                .AddProject(projectId, "TestProject", "TestProject", LanguageNames.CSharp)
+                .AddMetadataReference(projectId, CorlibReference)
+                .AddMetadataReference(projectId, SystemCoreReference)
+                .AddMetadataReference(projectId, CSharpSymbolsReference)
+                .AddMetadataReference(projectId, CodeAnalysisReference)
+                .AddMetadataReference(projectId, NServiceBusReference)
+                .AddMetadataReference(projectId, CallbacksReference);
+
+#if NETCOREAPP2_0
+            var netstandard = MetadataReference.CreateFromFile(System.Reflection.Assembly.Load("netstandard").Location);
+            var systemTasks = MetadataReference.CreateFromFile(System.Reflection.Assembly.Load("System.Threading.Tasks").Location);
+            var systemRuntime = MetadataReference.CreateFromFile(System.Reflection.Assembly.Load("System.Runtime").Location);
+            solution = solution.AddMetadataReferences(projectId, new[]
+            {
+                netstandard,
+                systemRuntime,
+                systemTasks
+            });
+#endif
+
+            var documentIndex = 0;
+            foreach (var source in sources)
+            {
+                var fileName = "Test" + documentIndex + ".cs";
+                solution = solution.AddDocument(DocumentId.CreateNewId(projectId, fileName), fileName, SourceText.From(source));
+                documentIndex++;
+            }
+
+            var documents = solution.GetProject(projectId).Documents.ToList();
+
+            if (sources.Length != documents.Count)
+            {
+                throw new InvalidOperationException("The number of documents created does not match the number of sources.");
+            }
+
+            var diagnostics = new List<Diagnostic>();
+            foreach (var project in new HashSet<Project>(documents.Select(document => document.Project)))
+            {
+                var compilationWithAnalyzers = project.GetCompilationAsync().Result.WithAnalyzers(ImmutableArray.Create(analyzer));
+
+                foreach (var diagnostic in await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync())
+                {
+                    if (diagnostic.Location == Location.None || diagnostic.Location.IsInMetadata)
+                    {
+                        diagnostics.Add(diagnostic);
+                    }
+                    else
+                    {
+                        foreach (var document in documents)
+                        {
+                            if (await document.GetSyntaxTreeAsync() == diagnostic.Location.SourceTree)
+                            {
+                                diagnostics.Add(diagnostic);
+                            }
+                        }
+                    }
+                }
+            }
+
+            return diagnostics.OrderBy(diagnostic => diagnostic.Location.SourceSpan.Start).ToArray();
+        }
+
+        static string FormatDiagnostics(DiagnosticAnalyzer analyzer, params Diagnostic[] diagnostics)
+        {
+            var builder = new StringBuilder();
+            for (var diagnosticIndex = 0; diagnosticIndex < diagnostics.Length; ++diagnosticIndex)
+            {
+                builder.AppendLine("// " + diagnostics[diagnosticIndex]);
+
+                var analyzerType = analyzer.GetType();
+                var descriptors = analyzer.SupportedDiagnostics;
+
+                foreach (var descriptor in descriptors
+                    .Where(descriptor => descriptor?.Id == diagnostics[diagnosticIndex].Id))
+                {
+                    var location = diagnostics[diagnosticIndex].Location;
+                    if (location == Location.None)
+                    {
+                        builder.AppendFormat("GetGlobalResult({0}.{1})", analyzerType.Name, descriptor.Id);
+                    }
+                    else
+                    {
+                        Assert.IsTrue(
+                            location.IsInSource,
+                            $"Test base does not currently handle diagnostics in metadata locations. Diagnostic in metadata: {diagnostics[diagnosticIndex]}\r\n");
+
+                        var position = diagnostics[diagnosticIndex].Location.GetLineSpan().StartLinePosition;
+
+                        builder.AppendFormat("{0}({1}, {2}, {3}.{4})",
+                            "GetResultAt",
+                            position.Line + 1,
+                            position.Character + 1,
+                            analyzerType.Name,
+                            descriptor.Id);
+                    }
+
+                    if (diagnosticIndex != diagnostics.Length - 1)
+                    {
+                        builder.Append(',');
+                    }
+
+                    builder.AppendLine();
+                    break;
+                }
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/src/NServiceBus.Callbacks.AnalyzerTests/NServiceBus.Callbacks.AnalyzerTests.csproj
+++ b/src/NServiceBus.Callbacks.AnalyzerTests/NServiceBus.Callbacks.AnalyzerTests.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net452;netcoreapp2.0;</TargetFrameworks>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NServiceBus.Callbacks\NServiceBus.Callbacks.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="NUnit" Version="3.7.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
+    <PackageReference Include="NServiceBus.Testing.Analyzer" Version="1.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/NServiceBus.Callbacks.sln
+++ b/src/NServiceBus.Callbacks.sln
@@ -18,6 +18,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\GitVersion.yml = ..\GitVersion.yml
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.Callbacks.AnalyzerTests", "NServiceBus.Callbacks.AnalyzerTests\NServiceBus.Callbacks.AnalyzerTests.csproj", "{3CA6E557-61FE-4918-BB70-C7BF79CDAA4C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -82,6 +84,18 @@ Global
 		{D5BBDC24-229F-41DC-828F-D2DE97FFC6B6}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{D5BBDC24-229F-41DC-828F-D2DE97FFC6B6}.Release|x86.ActiveCfg = Release|Any CPU
 		{D5BBDC24-229F-41DC-828F-D2DE97FFC6B6}.Release|x86.Build.0 = Release|Any CPU
+		{3CA6E557-61FE-4918-BB70-C7BF79CDAA4C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3CA6E557-61FE-4918-BB70-C7BF79CDAA4C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3CA6E557-61FE-4918-BB70-C7BF79CDAA4C}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{3CA6E557-61FE-4918-BB70-C7BF79CDAA4C}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{3CA6E557-61FE-4918-BB70-C7BF79CDAA4C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3CA6E557-61FE-4918-BB70-C7BF79CDAA4C}.Debug|x86.Build.0 = Debug|Any CPU
+		{3CA6E557-61FE-4918-BB70-C7BF79CDAA4C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3CA6E557-61FE-4918-BB70-C7BF79CDAA4C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3CA6E557-61FE-4918-BB70-C7BF79CDAA4C}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{3CA6E557-61FE-4918-BB70-C7BF79CDAA4C}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{3CA6E557-61FE-4918-BB70-C7BF79CDAA4C}.Release|x86.ActiveCfg = Release|Any CPU
+		{3CA6E557-61FE-4918-BB70-C7BF79CDAA4C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
adds tests to verify the async analyzer from core properly warns when missing awaits on `Request<T>` calls