### PR TITLE
WIP-support 20 update dev tooling

### DIFF
--- a/src/NServiceBus.Callback.Testing.Tests/NServiceBus.Callback.Testing.Tests.csproj
+++ b/src/NServiceBus.Callback.Testing.Tests/NServiceBus.Callback.Testing.Tests.csproj
@@ -15,11 +15,13 @@
     <PackageReference Include="ApprovalUtilities" Version="3.0.13" />
     <PackageReference Include="Castle.Core" Version="3.3.3" />
     <PackageReference Include="Castle.Windsor" Version="3.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Mono.Cecil" Version="0.10.0-beta6" />
     <PackageReference Include="NServiceBus" Version="6.1.0" />
     <PackageReference Include="NServiceBus.Testing" Version="6.0.2" />
-    <PackageReference Include="NUnit" Version="3.7.1" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="ApiApprover" Version="6.1.0-beta2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
     <PackageReference Include="PublicApiGenerator" Version="6.1.0-beta2" />
     <ProjectReference Include="..\NServiceBus.Callbacks.Testing\NServiceBus.Callbacks.Testing.csproj" />
     <ProjectReference Include="..\NServiceBus.Callbacks\NServiceBus.Callbacks.csproj" />

--- a/src/NServiceBus.Callbacks.AcceptanceTests/NServiceBus.Callbacks.AcceptanceTests.csproj
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/NServiceBus.Callbacks.AcceptanceTests.csproj
@@ -7,9 +7,11 @@
     <NoWarn>PCR0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="6.1.0" />
     <PackageReference Include="NServiceBus" Version="6.1.0" />
-    <PackageReference Include="NUnit" Version="3.7.1" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
     <ProjectReference Include="..\NServiceBus.Callbacks\NServiceBus.Callbacks.csproj" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Messaging" />

--- a/src/NServiceBus.Callbacks.Tests/NServiceBus.Callbacks.Tests.csproj
+++ b/src/NServiceBus.Callbacks.Tests/NServiceBus.Callbacks.Tests.csproj
@@ -13,11 +13,13 @@
     <Compile Remove="NServiceBus.Callbacks.approved.cs" />
     <PackageReference Include="ApprovalTests" Version="3.0.13" />
     <PackageReference Include="ApprovalUtilities" Version="3.0.13" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Mono.Cecil" Version="0.10.0-beta6" />
     <PackageReference Include="NServiceBus" Version="6.1.0" />
     <PackageReference Include="NServiceBus.Testing" Version="6.0.2" />
-    <PackageReference Include="NUnit" Version="3.7.1" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="ApiApprover" Version="6.1.0-beta2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
     <PackageReference Include="PublicApiGenerator" Version="6.1.0-beta2" />
     <ProjectReference Include="..\NServiceBus.Callbacks.Testing\NServiceBus.Callbacks.Testing.csproj" />
     <ProjectReference Include="..\NServiceBus.Callbacks\NServiceBus.Callbacks.csproj" />

--- a/src/NServiceBus.Callbacks/NServiceBus.Callbacks.csproj
+++ b/src/NServiceBus.Callbacks/NServiceBus.Callbacks.csproj
@@ -19,6 +19,10 @@
     <PackageReference Include="Particular.CodeRules" Version="0.2.0" />
     <PackageReference Include="NuGetPackager" Version="0.6.3" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012" />
+    <PackageReference Include="Particular.Packaging" Version="0.2.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <None Include="..\..\GitVersion.yml" Link="GitVersion.yml" />
     <None Include="..\..\packaging\nuget\NServiceBus.Callbacks.nuspec" Link="NServiceBus.Callbacks.nuspec" />
   </ItemGroup>


### PR DESCRIPTION
This updates development tooling on the `support-2.0` branch.
Note: This should not be squashed.