### PR TITLE
Ignore bad versioning commit

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -8,3 +8,6 @@ branches:
     tracks-release-branches: true
   release:
     tag: ''
+ignore:
+  sha:
+    - 89e6cfe802534086c8bff6dc662db243bfe6e8c3


### PR DESCRIPTION
This commit needs to be ignored because we merged and reverted a 2.1 release in the branch.