### PR TITLE
upgrade to latest NServiceBus.Testing 8.0.0 alpha

### DIFF
--- a/src/NServiceBus.Callback.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Callback.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -5,7 +5,7 @@ namespace NServiceBus.Callbacks.Testing
     public class TestableCallbackAwareSession : NServiceBus.Testing.TestableMessageSession
     {
         public TestableCallbackAwareSession() { }
-        public override System.Threading.Tasks.Task Send(object message, NServiceBus.SendOptions options) { }
+        public override System.Threading.Tasks.Task Send(object message, NServiceBus.SendOptions options, System.Threading.CancellationToken cancellationToken = default) { }
         public void When<TRequest, TResult>(System.Func<TRequest, bool> matcher, TResult response)
             where TRequest :  class { }
         public void When<TRequest, TResult>(System.Func<TRequest, NServiceBus.SendOptions, bool> matcher, TResult response)

--- a/src/NServiceBus.Callback.Testing.Tests/NServiceBus.Callback.Testing.Tests.csproj
+++ b/src/NServiceBus.Callback.Testing.Tests/NServiceBus.Callback.Testing.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1895" />
-    <PackageReference Include="NServiceBus.Testing" Version="8.0.0-alpha.168" />
+    <PackageReference Include="NServiceBus.Testing" Version="8.0.0-alpha.185" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Particular.Approvals" Version="0.3.0" />

--- a/src/NServiceBus.Callback.Testing.Tests/NServiceBus.Callback.Testing.Tests.csproj
+++ b/src/NServiceBus.Callback.Testing.Tests/NServiceBus.Callback.Testing.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1895" />
-    <PackageReference Include="NServiceBus.Testing" Version="8.0.0-alpha.155" />
+    <PackageReference Include="NServiceBus.Testing" Version="8.0.0-alpha.168" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Particular.Approvals" Version="0.3.0" />

--- a/src/NServiceBus.Callbacks.Testing/NServiceBus.Callbacks.Testing.csproj
+++ b/src/NServiceBus.Callbacks.Testing/NServiceBus.Callbacks.Testing.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Testing" Version="[8.0.0-alpha.155, 9.0.0)" />
+    <PackageReference Include="NServiceBus.Testing" Version="[8.0.0-alpha.168, 9.0.0)" />
     <PackageReference Include="Particular.Packaging" Version="1.2.1" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/NServiceBus.Callbacks.Testing/NServiceBus.Callbacks.Testing.csproj
+++ b/src/NServiceBus.Callbacks.Testing/NServiceBus.Callbacks.Testing.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Testing" Version="[8.0.0-alpha.168, 9.0.0)" />
+    <PackageReference Include="NServiceBus.Testing" Version="[8.0.0-alpha.185, 9.0.0)" />
     <PackageReference Include="Particular.Packaging" Version="1.2.1" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/NServiceBus.Callbacks.Testing/TestableCallbackAwareSession.cs
+++ b/src/NServiceBus.Callbacks.Testing/TestableCallbackAwareSession.cs
@@ -6,6 +6,7 @@
     using System.Threading.Tasks;
     using Extensibility;
     using NServiceBus.Testing;
+    using System.Threading;
 
     public class TestableCallbackAwareSession : TestableMessageSession
     {
@@ -26,9 +27,9 @@
             }, response));
         }
 
-        public override async Task Send(object message, SendOptions options)
+        public override async Task Send(object message, SendOptions options, CancellationToken cancellationToken = default)
         {
-            await base.Send(message, options).ConfigureAwait(false);
+            await base.Send(message, options, cancellationToken).ConfigureAwait(false);
 
             if (options.GetExtensions().TryGet(out RequestResponseStateLookup.State state))
             {


### PR DESCRIPTION
Upgrading from 8.0.0-alpha.155 to 8.0.0-alpha.168 causes a `StackOverflowException`. 👌 

Upgrading to the current latest, 8.0.0-alpha.183, does _not_ solve the problem.