### PR TITLE
Use C# 12 collection expressions

### DIFF
--- a/src/NServiceBus.Callbacks.AcceptanceTests/DefaultServer.cs
+++ b/src/NServiceBus.Callbacks.AcceptanceTests/DefaultServer.cs
@@ -11,7 +11,7 @@
     {
         public DefaultServer()
         {
-            typesToInclude = new List<Type>();
+            typesToInclude = [];
         }
 
         public DefaultServer(List<Type> typesToInclude)


### PR DESCRIPTION
This change satisfies the new `IDE0028` analyzer rules in the .NET 8 SDK.